### PR TITLE
docs: use teal as the site primary colour

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,14 +18,14 @@ theme:
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: deep purple
+      primary: teal
       accent: amber
       toggle:
         icon: material/weather-night
         name: Use dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: deep purple
+      primary: teal
       accent: amber
       toggle:
         icon: material/weather-sunny


### PR DESCRIPTION
`primary: deep purple` → `primary: teal` in both palette entries of
`mkdocs.yml`. `accent: amber` is unchanged — it stays the shared ecosystem
accent, so the site still reads as part of the family.

Hue distance from `goldilocks-ml`: 270° → 174°, 96° apart, which is enough to
tell the two sites apart as browser tabs. `teal` has adequate contrast in both
the `default` and `slate` schemes, so no per-scheme override was needed.

## Verification

- `uv run --frozen mkdocs build --strict` passes
- `site/index.html` renders `data-md-color-primary="teal"` for both the light
  and dark palette entries

Closes #13

---
Written by an agent on behalf of @junwen94.
