### PR TITLE
ci(docs): add workflow_dispatch so the site can be redeployed on demand

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -32,13 +33,13 @@ jobs:
         run: uv run --frozen mkdocs build --strict
 
       - name: Upload GitHub Pages artifact
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v4
         with:
           path: site
 
   deploy:
-    if: github.event_name == 'push'
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Adds `workflow_dispatch:` to the Documentation workflow so the site can be
redeployed without pushing to `main`.

The trigger alone would not have been enough. Both the artefact upload step and
the `deploy` job were gated on `github.event_name == 'push'`, so a manual run
would have built the site and then deployed nothing. Both now read
`!= 'pull_request'`, which admits `push` and `workflow_dispatch` while keeping
pull requests build-only.

`concurrency.cancel-in-progress` is left as-is: it evaluates false for
`workflow_dispatch`, matching the existing `push` behaviour, so a manual deploy
will not be cancelled by a subsequent one.

## Why this was needed

After switching GitHub Pages from the legacy branch source to
`build_type: workflow`, the site kept serving the stale Jekyll deployment and
there was no way to trigger a rebuild — the only route was re-running the
historical merge run for #12.

## Verification

- Workflow YAML parses; triggers are `push`, `pull_request`, `workflow_dispatch`
- Both `if` conditions confirmed as `github.event_name != 'pull_request'`
- The build job on this PR exercises the pull-request path (build, no deploy)
- The manual path can only be exercised after merge, since `workflow_dispatch`
  is read from the default branch

`stfc/goldilocks-ml` has the same workflow and the same gap; noted in #14 as
worth mirroring.

Closes #14

---
Written by an agent on behalf of @junwen94.
