### PR TITLE
docs: commit the agent configuration (AGENTS.md, .agents/skills, .claude symlinks)

### DIFF
--- a/.agents/skills/catchup/SKILL.md
+++ b/.agents/skills/catchup/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: catchup
+description: Orient yourself at session start — check issues, PRs, branch state, and recent progress. Use when starting a new session, resuming after a break, or when you need to understand what was accomplished last. Prevents redoing completed work.
+---
+
+# Catchup: Session Start
+
+Verify project state before starting work. Each agent session is ephemeral — previous work may sit on an unmerged branch, an open PR, or a stale issue. Without checking, you risk redoing completed work.
+
+## Protocol
+
+### 1. Check Git State
+
+```bash
+# Current branch and tracking
+git status -sb
+
+# Feature branches with potential work
+git branch -a
+
+# Local commits not on remote
+git log origin/HEAD..HEAD --oneline 2>/dev/null
+```
+
+### 2. Check Open PRs
+
+```bash
+gh pr list --repo stfc/goldilocks-data --state open --limit 10
+gh pr checks <number> --repo stfc/goldilocks-data
+```
+
+For each open PR, note: which issue it closes, whether checks pass, and whether it's been reviewed.
+
+### 3. Read Recent Issue Activity
+
+```bash
+gh issue list --repo stfc/goldilocks-data --state open --limit 10
+gh issue list --repo stfc/goldilocks-data --state all --limit 5 --search "sort:updated-desc"
+```
+
+Read the most recently updated issues. Check their comments for progress reports from previous sessions.
+
+Focus on:
+- **Open questions** — unresolved decisions that block work
+- **Next steps** — what was the intended next action?
+- **Blockers** — is anything waiting on review, external input, or another PR?
+
+### 4. Cross-Reference
+
+Compare what you found:
+- Branch exists locally, not pushed → risk of lost work
+- Branch pushed, no PR → risk another session won't find it
+- PR open, not merged → starting new work may cause conflicts
+- Issue says "in progress" but no branch → stale status
+- PR merged but issue still open → close it
+- Recent issue comments disagree with the actual branch or PR state → fix the record
+
+### 5. Present Summary
+
+```markdown
+## Project State
+
+**Branch**: [current]
+**Open PRs**: [list or none]
+**Issue activity**: [what's in flight]
+
+### Pending Work
+- Issue #N: [status, what's left]
+- Issue #M: [status, what's left]
+
+### Discrepancies
+- [Any mismatch between issues/comments and actual git state]
+
+### Recommended Next Step
+[What to do next, based on the above]
+```
+
+## After Catchup
+
+1. Fix discrepancies first — push stranded branches, close stale issues, correct issue/PR status
+2. Confirm the next step with the user
+3. Proceed with work
+
+If catchup reveals completed work that wasn't integrated:
+- **Do NOT redo the work.** Push, PR, or merge the existing work first.

--- a/.agents/skills/dft-basics/SKILL.md
+++ b/.agents/skills/dft-basics/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: dft-basics
+description: Domain triage and reference for the DFT physics behind goldilocks-data campaigns. Load when touching k-points, pseudopotentials, smearing, convergence criteria, spin treatment, or scientific defaults.
+---
+
+# DFT Basics
+
+Goldilocks recommends DFT calculation inputs. This skill keeps the physics decisions separate from code-formatting mechanics.
+
+Use it when you need to decide *why* a parameter should be advised, selected, warned about, or left to the user. Do not use it as a substitute for target-code documentation; always verify syntax and edge cases against the implemented code path.
+
+## Progressive disclosure
+
+Start here, then load the reference file that matches the physics question.
+
+- `references/k-points.md` — Brillouin-zone sampling, Gamma conventions, k-spacing, mesh ranking, and code-specific caveats.
+- `references/pseudopotentials.md` — NC/ultrasoft/PAW, functional matching, relativistic treatment, SSSP families, cutoffs, and SOC pseudopotential requirements.
+- `references/smearing-soc-convergence.md` — smearing, spin polarization, SOC relevance, convergence thresholds, and mixing.
+
+If a change touches more than one domain, read each matching reference.
+
+## Working pattern
+
+1. **Classify the question** — k-points, pseudopotentials, smearing, SOC, convergence, or cross-cutting advice/provenance.
+2. **Read the matching reference** before changing physics-bearing code or docs.
+3. **Separate stages**:
+   - Analysis reports facts about the structure.
+   - Advice chooses scientific or numerical intent.
+   - Selection resolves advice into concrete files, grids, cutoffs, or settings.
+   - Generation translates completed decisions into target-code syntax.
+4. **Record provenance** for scientific choices: user hint, analysis-derived decision, default, lookup, model, or fallback.
+5. **Verify code-specific semantics** before encoding assumptions. In particular, k-point shifts, Gamma inclusion, relativistic flags, and SOC settings differ by code.
+
+## Quick principles
+
+- Do not silently enable expensive physics. For example, heavy elements should usually trigger SOC consideration, not automatic SOC.
+- Do not let generators invent scientific defaults. Put those choices in advice or selection records.
+- Do not assume PAW means fully relativistic or all-electron. PAW is usually still frozen-core, and relativistic treatment is a separate dataset property.
+- Do not assume even k-point grids miss Gamma. Gamma inclusion depends on the grid convention and shift.
+- Prefer conservative warnings when the code cannot know the science question.
+
+## Target codes
+
+Goldilocks may target multiple DFT codes. Support must be verified in the codebase; do not assume a target is implemented just because it is listed here.
+
+Common target codes:
+- **Quantum ESPRESSO** — plane-wave pseudopotential code. Input is Fortran namelists plus cards.
+- **VASP** — plane-wave PAW code. Uses POSCAR, INCAR, KPOINTS, and POTCAR. POTCAR files are licensed, so tools should not ship them.
+- **CASTEP** — plane-wave pseudopotential code. Input is `.cell` and `.param` files.
+- **ONETEP** — linear-scaling DFT code, common in UK materials modelling.

--- a/.agents/skills/dft-basics/references/k-points.md
+++ b/.agents/skills/dft-basics/references/k-points.md
@@ -1,0 +1,76 @@
+# k-points
+
+DFT integrates over the Brillouin zone. k-points sample that integration. Too few k-points can make energies, forces, stresses, and electronic properties inaccurate. Too many k-points waste compute.
+
+## Grids and Gamma conventions
+
+Monkhorst-Pack-style grids are standard for periodic systems. They are usually expressed as explicit dimensions:
+
+```text
+(nk1, nk2, nk3)
+```
+
+Gamma-centered means the grid includes Γ, but the details are convention- and code-dependent.
+
+For Quantum ESPRESSO `K_POINTS automatic`, the three trailing shift flags use this convention:
+
+- `0 0 0` — unshifted grid; Gamma is included.
+- `1 1 1` — half-grid shift in each direction.
+
+Do not assume that “even grid = misses Gamma”. Gamma inclusion depends on both the grid and the shift convention. Odd grids are often convenient for symmetric unshifted meshes, but they are not a universal rule.
+
+## k-spacing and reciprocal lattice convention
+
+K-point density can be represented as a reciprocal-space spacing in Å⁻¹. The package converts spacing to a mesh using reciprocal lattice vector lengths.
+
+The current k-mesh code uses pymatgen's solid-state reciprocal lattice convention, which includes the `2π` factor. That matches VASP-style `KSPACING` semantics:
+
+```text
+N_i = max(1, ceil(|b_i| / spacing))
+```
+
+where `|b_i|` is the reciprocal lattice vector length for direction `i`.
+
+When touching this code, be explicit about whether a spacing is crystallographic reciprocal length or solid-state reciprocal length including `2π`.
+
+## Representations used in this package
+
+Goldilocks may encounter several related k-mesh representations:
+
+- **k-distance / k-spacing** in Å⁻¹ — target maximum reciprocal-space spacing.
+- **mesh** `(nk1, nk2, nk3)` — explicit grid dimensions.
+- **k-distance interval** — range of spacing values that map to the same mesh.
+- **k-line density interval** — range of line-density values that map to the same mesh. For one axis, the admissible range is `[(n_k - 0.5) / |b*|, (n_k + 0.5) / |b*|]`, where `n_k` is the grid dimension and `|b*|` is the reciprocal vector length. For a full mesh, intersect the three per-axis ranges; if they do not overlap, the scalar interval is undefined.
+- **k-index** — integer rank for distinct meshes; the ML model predicts this kind of rank.
+- **k-pra** — k-points per reciprocal atom, typically `n_atoms × nk1 × nk2 × nk3`.
+- **n_reduced_kpoints** — number of symmetry-irreducible k-points after symmetry reduction.
+
+Do not stuff all of these into user-facing advice unless the interface actually needs them. They are useful for ranking, provenance, diagnostics, and compatibility tests.
+
+## Trade-offs
+
+- Metals usually need denser k-point meshes than insulators because the Fermi surface is sharp.
+- Small primitive cells usually need denser meshes than large supercells.
+- 2D and 1D systems need fewer k-points in non-periodic directions, but the code must know which directions are non-periodic before making that choice.
+- Symmetry can reduce the number of irreducible k-points and cost, but the full mesh still controls sampling density.
+
+## Advice vs selection
+
+Keep these stages separate:
+
+- **Analysis** may report dimensionality, cell lengths, reciprocal lengths, and symmetry facts.
+- **Advice** may recommend a target spacing, accuracy level, or whether metallic systems need denser sampling.
+- **Selection** converts advice into a concrete mesh and shift.
+- **Generation** writes the selected mesh in the target code's syntax.
+
+Generators should not silently decide k-point density. If they need a value, it should already exist in advice or selection.
+
+## Tests to protect
+
+When changing k-point code, prefer tests that assert behaviours rather than implementation trivia:
+
+- spacing-to-mesh conversion uses the documented reciprocal lattice convention
+- anisotropic cells produce anisotropic meshes
+- Gamma/shift handling matches the target code convention
+- model-predicted k-index maps to the expected mesh entry
+- old public fields remain available if compatibility requires them

--- a/.agents/skills/dft-basics/references/pseudopotentials.md
+++ b/.agents/skills/dft-basics/references/pseudopotentials.md
@@ -1,0 +1,92 @@
+# Pseudopotentials
+
+Atoms contain tightly bound core electrons and chemically active valence electrons. Pseudopotentials replace the all-electron potential near the nucleus with an effective potential acting on the valence electrons, reducing computational cost.
+
+## Pseudopotential and PAW types
+
+Common dataset types:
+
+| Type | Meaning | Typical consequence |
+|------|---------|---------------------|
+| NC / norm-conserving | Conserves valence norm outside the core region. | Often transferable and conceptually simpler, but usually needs higher wavefunction cutoffs. |
+| Ultrasoft | Relaxes norm conservation and uses augmentation charges. | Often lower wavefunction cutoffs, but requires charge-density augmentation and separate charge-density cutoffs. |
+| PAW | Projector augmented-wave dataset with information for reconstructing all-electron-like quantities near the core. | Often efficient and accurate, but dataset details and licensing matter. |
+
+PAW retaining all-electron reconstruction information does **not** mean the calculation explicitly solves every core electron. In most practical PAW calculations, core electrons are still treated as frozen core. PAW is better understood as retaining more core-region/all-electron information than standard NC or ultrasoft pseudopotentials, not as a full all-electron calculation.
+
+## Relativistic treatment is separate from pseudo type
+
+NC, ultrasoft, and PAW datasets can each be generated with different relativistic treatments.
+
+| Treatment | Meaning | Use |
+|-----------|---------|-----|
+| Non-relativistic | Does not include relativistic effects. | Less common in modern libraries; may be acceptable for some light-element cases. |
+| Scalar-relativistic | Includes scalar relativistic effects such as mass-velocity and Darwin terms, but not explicit spin-orbit coupling. | Common default for many routine calculations. |
+| Fully-relativistic | Includes ingredients needed for explicit spin-orbit coupling and noncollinear calculations. | Needed when doing SOC explicitly. |
+
+Do not assume PAW automatically means fully-relativistic. Do not assume fully-relativistic automatically means PAW. They are different axes.
+
+## Functional consistency
+
+The exchange-correlation functional used to generate the pseudopotential should normally match the functional used in the DFT calculation:
+
+- PBE pseudo with PBE calculation
+- PBEsol pseudo with PBEsol calculation
+- LDA pseudo with LDA calculation
+
+Mixing functionals can sometimes be done deliberately, but Goldilocks should not recommend it silently.
+
+## SSSP families
+
+SSSP provides curated pseudopotential families for Quantum ESPRESSO workflows:
+
+- **Efficiency** — selected to reduce cost while maintaining acceptable accuracy for screening and high-throughput work.
+- **Precision** — selected for stricter accuracy, usually with higher cutoffs and greater computational cost.
+
+When a user asks for speed, screening, or exploratory runs, Efficiency may be appropriate. When they ask for production accuracy, final energies, forces, or benchmark-quality work, Precision is usually safer.
+
+## Cutoffs
+
+Plane-wave pseudopotential calculations need cutoffs, usually:
+
+- wavefunction cutoff, often `ecutwfc` in Quantum ESPRESSO
+- charge-density cutoff, often `ecutrho` in Quantum ESPRESSO
+
+Cutoffs should come from reliable metadata when possible. If metadata is missing, selection should emit a structured warning instead of letting a generator invent a quiet fallback.
+
+Ultrasoft and PAW datasets often need a higher charge-density cutoff relative to wavefunction cutoff than norm-conserving datasets.
+
+## Selection chain
+
+Keep pseudopotential work in stages:
+
+1. **Analyse** the structure and calculation target: elements, heavy elements, magnetic candidates, possible semicore needs, oxidation/valence concerns when known.
+2. **Advise** on family, functional, and relativistic treatment.
+3. **Select** concrete files for each element and derive cutoffs from metadata.
+4. **Generate** target-code syntax from the selected files and cutoffs.
+
+Generators should not choose pseudopotential families, relativistic treatment, or cutoffs. Those are scientific/numerical decisions.
+
+## SOC gotchas
+
+Spin-orbit calculations generally require fully-relativistic pseudopotentials or PAW datasets. A fully-relativistic file is not enough by itself: the target code must also be configured for SOC/noncollinear calculation.
+
+For Quantum ESPRESSO, explicit SOC calculations usually require settings such as:
+
+```text
+noncolin = .true.
+lspinorb = .true.
+```
+
+Whether scalar-relativistic and fully-relativistic pseudopotentials can be mixed is code- and setup-dependent. A conservative workflow selects a consistent relativistic treatment across all elements and validates the setup against the target code.
+
+## Warnings worth preserving
+
+Selection should warn when:
+
+- no pseudopotential exists for an element in the requested family
+- the requested functional is unavailable
+- SOC is requested but fully-relativistic data is unavailable
+- cutoff metadata is missing or incomplete
+- a fallback family, functional, or relativistic treatment is used
+- selected pseudopotentials mix treatments in a way the target code may not support

--- a/.agents/skills/dft-basics/references/smearing-soc-convergence.md
+++ b/.agents/skills/dft-basics/references/smearing-soc-convergence.md
@@ -1,0 +1,83 @@
+# Smearing, SOC, and convergence
+
+This reference covers physics-bearing defaults that often interact with k-points and pseudopotentials.
+
+## Smearing
+
+Metals have a Fermi surface where occupation changes abruptly from occupied to unoccupied states. Small energy changes can cause large occupation changes, which makes self-consistent-field convergence harder. Smearing smooths this transition.
+
+Common choices:
+
+| Choice | Meaning | Notes |
+|--------|---------|-------|
+| Fixed occupations / no smearing | Occupations are not smeared. | Appropriate for many insulators and semiconductors when band occupations are clear. |
+| Gaussian | Simple smooth broadening. | Conservative and useful for testing. |
+| Methfessel-Paxton | Polynomial smearing, common for metals. | Higher-order MP can produce negative occupations; first-order MP is common. |
+| Cold / Marzari-Vanderbilt | Smearing designed for lower energy bias. | Often a good general-purpose metallic smearing. |
+
+Typical starting guidance:
+
+- Metallic system → cold smearing or first-order Methfessel-Paxton, width roughly `0.01–0.02 Ry` as a starting point for Quantum ESPRESSO.
+- Insulating system → fixed occupations, or narrow Gaussian/cold smearing if convergence needs help.
+
+The width matters:
+
+- Too wide → occupations and energies can become unphysical.
+- Too narrow → SCF may fail to converge or converge slowly.
+
+Goldilocks should distinguish “likely metal” from “known metal” when the band structure is not known. Use warnings and provenance rather than pretending the structure alone answers everything.
+
+## Spin polarization and magnetism
+
+Magnetic elements or partially filled d/f shells can require spin-polarized calculations. Structure analysis can identify likely magnetic elements, but it cannot always know the correct magnetic ordering or initial moments.
+
+Good advice should:
+
+- flag likely magnetic candidates
+- distinguish spin-polarized recommendation from exact magnetic ordering
+- allow user hints to override spin assumptions
+- avoid inventing detailed magnetic moments unless a source or explicit hint provides them
+
+## Spin-orbit coupling
+
+SOC can matter when electron spin couples strongly to orbital motion. It is especially relevant for heavy elements and for science questions involving band splittings, topology, magnetic anisotropy, or heavy-element chemistry.
+
+First-pass relevance heuristic:
+
+- period 5 and heavier elements are good SOC candidates
+- lanthanides and actinides are strong candidates
+- even one heavy element can make SOC relevant depending on the property of interest
+
+Do not silently enable SOC just because a structure contains heavy elements. SOC often costs several times more than scalar-relativistic calculations and changes the required pseudopotential and code settings. Advice should usually say “consider SOC” with provenance and warnings.
+
+SOC advice should connect to pseudopotential selection:
+
+- explicit SOC → prefer fully-relativistic pseudopotentials or PAW datasets
+- scalar-relativistic baseline → scalar-relativistic datasets are often appropriate
+- target-code setup must also enable SOC/noncollinear calculation where required
+
+## Convergence thresholds
+
+DFT calculations are iterative. Convergence parameters control when the self-consistent loop stops.
+
+Common parameters:
+
+- **Energy convergence threshold** — in Quantum ESPRESSO, `conv_thr` is in Ry. `1e-6 Ry` is a common default-level threshold; tighter values are used for precision work.
+- **Force convergence threshold** — in Quantum ESPRESSO, `forc_conv_thr` is in Ry/bohr. `1e-3 Ry/bohr` is a common default-level threshold for relaxation.
+- **Maximum SCF steps** — larger or harder systems may need more steps.
+- **Mixing beta** — controls how strongly new density/potential replaces old density/potential.
+
+Mixing tendencies:
+
+- mixing beta too high → oscillation or divergence
+- mixing beta too low → slow convergence
+- metals, magnetic systems, low-dimensional systems, and large cells often need gentler mixing
+
+## Advice boundaries
+
+Convergence advice should be conservative and transparent:
+
+- Tight thresholds increase cost; do not apply them silently.
+- Relaxation and final single-point calculations may need different thresholds.
+- Smearing, k-points, and convergence interact; changing one can expose problems in another.
+- If the code cannot infer a property, preserve uncertainty as a warning rather than hiding it in a default.

--- a/.agents/skills/github-cli/SKILL.md
+++ b/.agents/skills/github-cli/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: github-cli
+description: Use the gh CLI for GitHub issues, PRs, comments, checks, and Actions state in this repo. Use whenever reading or writing GitHub state from an agent session.
+---
+
+# GitHub CLI
+
+Use `gh` for GitHub work. Prefer structured commands over scraping web pages.
+
+Repo: `stfc/goldilocks-data`
+
+## Rules
+
+- Use `--repo stfc/goldilocks-data` unless you are already inside this repo and deliberately relying on the current remote.
+- Prefer `--json` and `--jq` for read operations so outputs are machine-checkable.
+- Use `--body-file` for long issue, comment, and PR bodies. Do not fight shell quoting goblins by pasting Markdown into one command.
+- Prefer issue comments for progress updates, reviews, decisions, blockers, and session reports. Edit issue bodies only when the issue's current plan/source-of-truth is stale or structurally wrong.
+- **Never merge directly to `main`.** All changes arrive through PRs.
+- Any GitHub issue, issue comment, PR description, or review comment written by an agent must include:
+
+```text
+Written by an agent on behalf of <user>.
+```
+
+Replace `<user>` with the human who requested the work.
+
+## Inspect state
+
+```bash
+gh issue list --repo stfc/goldilocks-data --state open --limit 20
+gh pr list --repo stfc/goldilocks-data --state open --limit 20
+gh pr view <number> --repo stfc/goldilocks-data --json state,mergeStateStatus,isDraft,reviewDecision,baseRefName,headRefName
+gh pr checks <number> --repo stfc/goldilocks-data
+gh run list --repo stfc/goldilocks-data --branch <branch>
+gh run view <run-id> --repo stfc/goldilocks-data --log
+```
+
+Use `gh api` for fields not exposed by high-level commands:
+
+```bash
+gh api repos/stfc/goldilocks-data/issues/<number> --jq '{title, state, body}'
+gh api repos/stfc/goldilocks-data/pulls/<number> --jq '{title, state, mergeable, rebaseable}'
+```
+
+## Create an issue
+
+Write the body to a temp file first:
+
+```bash
+cat > /tmp/issue-body.md <<'EOF'
+## Problem
+...
+
+## Approach
+...
+
+## Acceptance criteria
+- [ ] ...
+
+---
+Written by an agent on behalf of <user>.
+EOF
+
+gh issue create --repo stfc/goldilocks-data --title "type: short title" --body-file /tmp/issue-body.md
+```
+
+## Comment on an issue
+
+Use comments for timeline records: progress reports, reviews, verification results, decisions made during implementation, blockers, and handoff notes. A comment is usually the right move when you are adding new historical context rather than changing the plan itself.
+
+```bash
+cat > /tmp/comment.md <<'EOF'
+## Done
+- ...
+
+## Next
+- ...
+
+---
+Written by an agent on behalf of <user>.
+EOF
+
+gh issue comment <number> --repo stfc/goldilocks-data --body-file /tmp/comment.md
+```
+
+## Create a PR
+
+Before creating:
+
+```bash
+git status -sb
+git branch --show-current
+gh pr list --repo stfc/goldilocks-data --head "$(git branch --show-current)"
+```
+
+Then:
+
+```bash
+cat > /tmp/pr-body.md <<'EOF'
+## What
+...
+
+## Why
+Closes #<issue-number>.
+
+## How to test
+...
+
+## Changes
+- ...
+
+---
+Written by an agent on behalf of <user>.
+EOF
+
+gh pr create --repo stfc/goldilocks-data --title "type(scope): short title" --body-file /tmp/pr-body.md
+```
+
+## Edit existing GitHub text
+
+Issue body edits are for maintaining the current source of truth, not for recording every event. Use them when:
+
+- the issue is a plan and the plan materially changed;
+- acceptance criteria, scope, goals, or non-goals are stale;
+- tasks are completed and the checklist is the active tracker;
+- the body is misleading future work;
+- the user explicitly asks to consolidate or edit the issue.
+
+Do **not** edit the issue body just to add a review, routine verification output, progress report, or session handoff. Post those as comments.
+
+Fetch current content first, edit locally, then write it back:
+
+```bash
+gh issue view <number> --repo stfc/goldilocks-data --json body --jq .body > /tmp/body.md
+# edit /tmp/body.md
+gh issue edit <number> --repo stfc/goldilocks-data --body-file /tmp/body.md
+```
+
+For comments, use the API:
+
+```bash
+gh api repos/stfc/goldilocks-data/issues/<issue-number>/comments --jq '.[] | {id, body: .body[0:120]}'
+gh api repos/stfc/goldilocks-data/issues/comments/<comment-id> -X PATCH -f body="$(cat /tmp/comment.md)"
+```
+
+## Checks and Actions
+
+Use `gh pr checks` for the quick answer and `gh run` when you need workflow detail.
+
+```bash
+gh pr checks <number> --repo stfc/goldilocks-data
+gh run list --repo stfc/goldilocks-data --branch <branch>
+gh run view <run-id> --repo stfc/goldilocks-data --log
+gh run download <run-id> --repo stfc/goldilocks-data
+```
+
+If the repo has no workflows yet, say so plainly and rely on local verification instead of pretending CI exists.
+
+## Gotchas
+
+- `gh pr create` uses the current branch by default — verify branch and base before creating.
+- `gh issue edit --body-file` replaces the whole body. Fetch first so you do not erase context.
+- Before editing an issue body, ask: "Am I changing the current plan/source-of-truth, or just adding history?" If it is history, comment instead.
+- `gh api ... -f body="$(cat file)"` can mangle complex Markdown in some shells. If in doubt, use a small Python snippet to PATCH JSON.
+- GitHub CLI output may omit fields unless requested with `--json`; don't parse human tables when JSON exists.

--- a/.agents/skills/make-a-pr/SKILL.md
+++ b/.agents/skills/make-a-pr/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: make-a-pr
+description: Commit and open a pull request. Use when you have changes ready to submit — after implementing, testing, and self-reviewing.
+---
+
+# Make a PR
+
+## Branch
+
+1. Create a feature branch from main: `feat/short-description` or `fix/short-description`.
+2. **Never push or merge directly to `main`.** All changes arrive through PRs.
+
+## Commit
+
+1. One logical change per commit. Fixing lint and adding a feature = two commits.
+2. Conventional commits: `feat(scope): add ...`, `fix(scope): handle ...`, `docs: ...`, `test: ...`.
+3. First line under 50 chars, imperative mood. Add a body if the "why" isn't obvious.
+
+## Self-review
+
+Before pushing, review your own diff:
+
+```bash
+git diff main...HEAD
+```
+
+Check for:
+- Leftover debug prints, commented-out code, accidental formatting changes
+- Missing tests for new public functions
+- Changes you don't remember making
+
+## Pre-commit
+
+```bash
+uv run pre-commit run --all-files
+```
+
+Fix any failures before pushing.
+
+## Push
+
+```bash
+git push -u origin feat/short-description
+```
+
+## Open the PR
+
+```bash
+gh pr create --title "feat(scope): short description" --body-file pr-body.md
+```
+
+PR body template:
+
+```markdown
+## What
+One-sentence summary of the change.
+
+## Why
+Context — what problem does this solve? Reference the issue: Closes #N.
+
+## How to test
+Concrete steps a reviewer can follow to verify the change works.
+Commands, expected outputs, or how to exercise new behaviour.
+
+## Changes
+- Bullet list of the meaningful changes. Not every file — the stuff that matters.
+
+---
+Written by an agent on behalf of <user>.
+```
+
+## After opening
+
+- PR descriptions written by an agent must include `Written by an agent on behalf of <user>.`, replacing `<user>` with the human who requested the work.
+- Make sure the PR body includes `Closes #N` for the linked issue.
+- If CI exists, inspect checks with `gh pr checks <number>`.
+- If GitHub Actions workflows exist and you need more detail, use `gh run list --branch <branch>` and `gh run view <run-id> --log`.
+- If there is no CI yet, say so plainly and rely on local verification results in the PR body.
+- Respond to review comments by pushing new commits — don't force-push reviewed code unless asked.
+
+## Merging
+
+- Only merge after review approval and passing CI when CI exists.
+- The `Closes #N` in the PR body auto-closes the issue on merge.

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: plan
+description: Create an implementation plan as a GitHub Issue. Use when the user asks to plan a feature, refactor, bugfix, or multi-step task. Also use when breaking down work before starting implementation.
+argument-hint: [topic or feature to plan]
+---
+
+# Plan: Create an Issue
+
+Plan: **$ARGUMENTS**
+
+Create a structured plan as a GitHub Issue. The issue body serves as the plan document — it persists across sessions, is searchable, and can be referenced by PRs.
+
+## Planning Principles
+
+**Keep plans proportional to the task.** A quick fix needs a short issue. A multi-phase refactor needs phases, tasks, and acceptance criteria. Match the plan's weight to the work's complexity.
+
+**Specify direction, not line numbers.** Identify files and describe what changes. Include draft code for key interfaces and non-obvious logic — real code that conveys the design.
+
+**Plans are for orientation, not control.** A good plan helps the implementer understand *what* to build and *why*, then gets out of the way.
+
+## Planning Process
+
+1. **Research** — explore the codebase to understand current structure and constraints
+2. **Design** — define scope, goals, and key decisions
+3. **Write** — create a GitHub Issue with the plan
+4. **Track** — keep the issue body current when the plan changes; use comments/PR links for progress, reviews, verification, and handoff history
+
+## Issue Templates
+
+### Lightweight (single-session work)
+
+```markdown
+## Problem
+What's wrong or what's needed. Specific.
+
+## Approach
+How to tackle it. Files to touch, key changes.
+
+## Acceptance Criteria
+- [ ] [testable condition]
+- [ ] [testable condition]
+
+---
+Written by an agent on behalf of <user>.
+```
+
+```bash
+gh issue create --title "feat: short description" --body-file plan.md
+```
+
+### Full (multi-phase work)
+
+```markdown
+## Problem
+What's wrong or what's needed. Why it matters.
+
+## Goals
+- Goal 1
+- Goal 2
+
+## Non-Goals
+- What this plan explicitly does NOT address.
+
+## Approach
+High-level design decisions and rationale.
+Include draft code for key interfaces.
+
+## Phases
+
+### Phase 1: [Name]
+**Goal:** What this phase accomplishes
+
+Tasks:
+- [ ] P1-T1: Description
+- [ ] P1-T2: Description
+
+Verification: How to check this phase is complete.
+
+### Phase 2: [Name]
+(repeat)
+
+## Open Questions
+- Question 1?
+- Question 2?
+
+---
+Written by an agent on behalf of <user>.
+```
+
+```bash
+gh issue create --title "feat: short description" --body-file plan.md
+```
+
+## After Creating
+
+1. Summarize the plan for the user
+2. Ask whether to proceed with implementation or refine the plan
+3. As phases complete, update checklist state in the issue body if that checklist is the active tracker
+4. Add progress, review results, verification output, and handoff notes as comments
+5. Link the issue from follow-up PRs and reports so the thread remains the durable record
+
+## Gotchas
+
+- Every issue body created by an agent must include `Written by an agent on behalf of <user>.`, replacing `<user>` with the human who requested the work.
+- Don't over-plan simple tasks — a 3-line issue for a typo fix is worse than just fixing it
+- Update the issue body as understanding evolves, but do not edit it for routine status notes
+- If the plan changes significantly, edit the issue — stale plans mislead future sessions
+- If you are adding historical context rather than changing the current plan, comment instead

--- a/.agents/skills/report/SKILL.md
+++ b/.agents/skills/report/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: report
+description: Write a progress report as a GitHub Issue comment. Use when ending a session, completing a milestone, hitting a blocker, or when the user asks for a handoff. Captures decisions, reasoning, git state, and next actions so future sessions can resume without context loss.
+argument-hint: [issue number to report on, or leave blank to infer]
+---
+
+# Report: Write a Progress Comment
+
+Document what was accomplished and what's next, as a comment on the relevant issue. This is how sessions hand off to each other — the issue thread becomes a persistent timeline of progress, decisions, and blockers.
+
+Issue: **$ARGUMENTS** (if blank, infer from the current branch or recent work)
+
+## Why This Matters
+
+Each agent session is ephemeral. Without a report, the next session has to reconstruct what happened from git history alone — which records *what* changed, not *why*. The issue thread fills that gap.
+
+## Report Process
+
+1. **Identify the issue** — which issue does this work belong to? If none exists, create one.
+2. **Review the session** — what was accomplished, what was decided, what remains.
+3. **Write a comment** on the issue.
+4. **Update the issue body only if needed** — approach, scope, acceptance criteria, or active checklist changed.
+5. **Update the issue/PR record** with the lightest durable action that fits: comments for history, body edits for current plan/source-of-truth changes.
+
+## Comment Format
+
+```markdown
+## Done
+- [what was accomplished]
+
+## Decisions
+- [choices made and why — especially when the obvious path was rejected]
+
+## Blockers / Open Questions
+- [anything unresolved]
+
+## Next
+- [what the next step is]
+
+---
+Written by an agent on behalf of <user>.
+```
+
+## When to Report
+
+- **End of a session** — always. Even if the session was short.
+- **After completing a milestone** — document the achievement while it's fresh.
+- **When hitting a blocker** — don't wait. Surface it so the next session (or a human) can act.
+- **When a decision is made** — record the reasoning, not just the outcome.
+
+## Updating the Issue Body
+
+Comments document the journey; the issue body documents the current understanding. Be conservative with body edits.
+
+Edit the issue body when:
+- the work changed the plan — new scope, different approach, or discovered complications;
+- acceptance criteria, goals, non-goals, or active task checklists are stale;
+- a phase is complete and the body checklist is the active tracker;
+- new open questions change what future sessions should do;
+- the user asks to consolidate or revise the issue.
+
+Do not edit the issue body for:
+- routine progress reports;
+- review findings;
+- verification command output;
+- session handoffs;
+- small decisions that do not change the plan.
+
+Post those as comments.
+
+## Updating Work Status
+
+Use the issue thread and PR state as the durable record.
+
+Common transitions:
+- Starting work → leave a report comment or push a branch linked to the issue
+- Opening a PR → link it clearly in an issue comment; edit the body only if the issue tracks active PR state there
+- PR merged → confirm completion and any follow-up work in a comment
+
+If status changed, say so explicitly in the report instead of assuming the next session will infer it.
+
+## Git State
+
+Always include current git state in the report so the next session can verify:
+
+```markdown
+## Git State
+- Branch: `feat/short-description`
+- Pushed: yes/no
+- PR: #N (open/merged/none)
+- Ready for next step: yes/no (blocked by: ...)
+```
+
+## Self-Review Before Handoff
+
+Before reporting, quick check:
+
+```bash
+# What did I actually change?
+git diff main...HEAD --stat
+
+# Did I leave debug prints or commented-out code?
+git diff main...HEAD | grep -E "^\+.*(# |print|breakpoint|pdb)"
+```
+
+Clean up anything embarrassing before you call it done.
+
+## Gotchas
+
+- Every issue comment written by an agent must include `Written by an agent on behalf of <user>.`, replacing `<user>` with the human who requested the work.
+- Always verify git state before writing it — don't assume from conversation context
+- If the report says "next: X", the next session should find X actionable — be specific
+- Don't bury important decisions in long prose — the Decisions section should be scannable
+- If you discovered a new issue or blocker during the session, file it as a separate issue — don't just mention it in a comment

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: review
+description: Review changes against main before opening a PR or when the user asks for review. Checks correctness, edge cases, architecture, regressions, test gaps, and compatibility-shim risk.
+---
+
+# Review
+
+Review the current changes before they leave this branch. Catch problems here, not in PR comments.
+
+## What to review
+
+Check both:
+- uncommitted changes in the working tree
+- commits on the current branch not on main
+
+```bash
+git status -sb
+git diff --stat
+git diff main...HEAD --stat
+git log main..HEAD --oneline 2>/dev/null
+```
+
+If there's nothing to review, say so and stop.
+
+## Review focus
+
+### Correctness
+- Does the code do what it claims? Check the logic, not just the intent.
+- Are there edge cases that break it? Empty inputs, single elements, boundary values, None/missing fields.
+- Are error paths handled? Do they raise the right exception with the right message?
+
+### Architecture
+- Does the change respect module boundaries? No cross-cutting imports that shouldn't exist.
+- Does it put logic in the right layer? Advisors orchestrate, generators translate, types carry data.
+- Does it introduce coupling that will be hard to undo?
+
+### Regressions
+- Does anything existing break? Run the tests.
+- Does the change change the public API surface without updating callers?
+- Are there implicit behavioural changes — different defaults, removed fallbacks, changed error handling?
+
+### Testing
+- Are new public functions tested?
+- Are edge cases covered, or just the happy path?
+- Do tests depend on `local_data/` or non-portable fixtures? They shouldn't.
+
+### Code quality
+- Leftover debug prints, commented-out code, TODO without an issue?
+- Does it follow the project code style? (Ruff should catch most of this, but check anyway.)
+- Are docstrings factual, or do they contain implementation details that will rot?
+
+## Report findings
+
+Classify each finding:
+
+| Severity | Meaning |
+|----------|---------|
+| **Critical** | Broken behaviour, data loss, security issue. Must fix before merge. |
+| **High** | Likely bug, missing test for important path, architectural violation. Should fix. |
+| **Medium** | Minor bug, style inconsistency, fragile pattern. Fix if convenient. |
+| **Low** | Nit, opinion, nice-to-have. Mention but don't block on it. |
+
+Present a summary:
+
+```markdown
+## Review: [branch name]
+
+**Files changed:** N
+**Verdict:** ready / needs fixes / blocked
+
+### Findings
+
+| Severity | File | Issue |
+|----------|------|-------|
+| critical | path | description |
+| high | path | description |
+| ... | ... | ... |
+
+### No significant issues
+(If the branch is clean, say so explicitly — don't make the user wonder if you skipped something.)
+
+---
+Written by an agent on behalf of <user>.
+```
+
+## After review
+
+- If findings are critical or high, offer to fix them before opening the PR.
+- If findings are medium/low only, note them in the PR body and proceed.
+- If the branch is clean, proceed to open the PR.
+- If a durable review record is needed, post the review as an issue comment. Do not add review artifacts to the repository unless the user explicitly asks for a file.
+
+## Gotchas
+
+- If posting the review to GitHub, include `Written by an agent on behalf of <user>.`, replacing `<user>` with the human who requested the review.
+- Review findings are recommendations, not automatic truth. Verify file paths and claims before acting.
+- If `main` is stale locally, fetch first so you're comparing against a real baseline.
+- A very large branch will produce a broad, less precise review. Say so if that's the case.

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: skill-creator
+description: Create new skills or improve existing ones through an iterative draft → test → compare → revise loop. Use when the user wants to add a skill, port one from another harness, tune triggering, or make a skill more reliable.
+argument-hint: [skill name, path, or task]
+---
+
+# Skill Creator
+
+Create or improve a skill in a way that survives contact with reality.
+
+Topic: **$ARGUMENTS**
+
+This is the Pi-adapted version of Anthropic's skill-creator workflow. The core idea stays the same:
+
+1. understand what the skill should do
+2. write a draft
+3. test it on realistic prompts
+4. compare results to a baseline
+5. revise based on what actually happened
+6. repeat until the skill is clearly better
+
+The Pi adaptation changes the mechanics:
+- use Pi skills and files, not Claude Code-only features
+- use `agent` spawning when available, or work inline if not
+- store evals and outputs as normal files
+- use side-by-side markdown comparison by default instead of a custom viewer
+- avoid unsupported frontmatter or harness-specific assumptions
+
+---
+
+## What a Good Skill Looks Like
+
+A good skill is not just a clever prompt. It is:
+
+- **easy to trigger** — the description says what it does *and when to use it*
+- **lean** — the main `SKILL.md` stays focused; bulky detail moves to `references/` or scripts
+- **practical** — if the workflow repeatedly needs helper code, bundle a script instead of making the model reinvent it
+- **testable** — you can tell whether it helped on a few real tasks
+- **general** — it should not only work on the exact examples used during development
+
+When editing a skill, prefer explanation over command barking. If you keep writing `ALWAYS`, `NEVER`, or brittle step lists, stop and ask what behavior you are actually trying to induce.
+
+---
+
+## When to Create a Skill vs Do Something Else
+
+Create or improve a skill when the workflow is:
+- repeated across sessions or projects
+- annoying to restate every time
+- specialized enough that the model benefits from domain instructions
+- a mix of reference material, workflow, and helper scripts
+
+Do **not** make a skill when:
+- the rule belongs in `AGENTS.md` or project `CLAUDE.md`
+- the task is one-off
+- the process is so deterministic that a plain script is better than a skill
+- the workflow is still too vague to describe clearly
+
+---
+
+## Phase 1: Capture Intent
+
+Start by understanding what the skill is for.
+
+Pull as much as you can from the current conversation before interrogating the user. If they already described the workflow, do not make them repeat themselves.
+
+Figure out:
+
+1. **What should the skill enable?**
+2. **When should it trigger?**
+3. **What should success look like?**
+4. **Is this a reference skill, an action skill, or a hybrid?**
+5. **Does it need helper scripts or reference docs?**
+6. **Should the user invoke it manually, or should the model auto-load it?**
+
+Useful follow-up questions:
+- What are 2-3 real prompts a user might type?
+- What does a good output look like?
+- What mistakes would make the skill feel broken?
+- Does the workflow touch files, run scripts, or depend on external tools?
+- Is the skill Pi-specific, or are we porting from Claude Code/Codex/etc.?
+
+---
+
+## Phase 2: Research and Inspect
+
+Before writing, inspect the environment.
+
+### If improving an existing skill
+
+Read:
+- the current `SKILL.md`
+- supporting files in the skill directory
+- recent transcripts, reports, or examples showing where the skill worked or failed
+
+### If porting from another harness
+
+Read the source skill carefully and translate it, do not cargo-cult it.
+
+Look for harness-specific features such as:
+- `context: fork`
+- `allowed-tools`
+- Claude Code-specific subagent or viewer workflows
+- shell interpolation features Pi may not support
+- assumptions about built-in tools or command names
+
+Keep the underlying intent. Replace the mechanics.
+
+### If creating from scratch
+
+Look for neighboring skills that establish local style:
+- frontmatter shape
+- description style
+- section ordering
+- whether helper scripts or `references/` are used
+
+---
+
+## Phase 3: Write the First Draft
+
+Create the skill directory and write `SKILL.md`.
+
+### Frontmatter
+
+Include at minimum:
+
+```yaml
+---
+name: skill-name
+description: What the skill does and when to use it.
+---
+```
+
+Use `argument-hint` if the command benefits from arguments.
+
+### Description guidance
+
+The description is the trigger. Front-load the important bits.
+
+Weak:
+```yaml
+description: Helps with planning.
+```
+
+Better:
+```yaml
+description: Create implementation plans for features, refactors, and bug fixes. Use when the user asks to break down work, estimate scope, or turn a vague task into concrete steps.
+```
+
+### Body guidance
+
+Keep `SKILL.md` focused on:
+- what the skill is for
+- how to decide whether to use it
+- the workflow to follow
+- where to look next (`references/`, `scripts/`, templates)
+
+Move bulky detail out of the main file when:
+- a reference section gets long
+- examples pile up
+- there is a deterministic helper the model keeps recreating
+
+### Structure pattern
+
+```markdown
+# Skill Name
+
+What this skill is for.
+
+## When to use it
+- situation A
+- situation B
+
+## Workflow
+1. do this
+2. then this
+3. verify
+
+## Supporting files
+- `references/foo.md` — domain detail
+- `scripts/bar.sh` — deterministic helper
+```
+
+---
+
+## Phase 4: Create Realistic Eval Prompts
+
+Write 2-5 realistic prompts. These should sound like what an actual user would type, not benchmark gobbledygook.
+
+Good eval prompts:
+- resemble real user requests
+- cover normal use and at least one edge case
+- exercise the core promise of the skill
+
+Bad eval prompts:
+- restate the skill back to itself
+- over-explain the desired answer
+- only test the happy path
+
+Save them in a simple workspace so the loop is inspectable.
+
+## Workspace Layout
+
+Use a temporary workspace while developing or evaluating a skill. In this repository, do not commit `skill-workspace/` directories unless the user explicitly asks to preserve skill-evaluation artifacts. The committed skill should normally contain `SKILL.md` plus deliberate `references/`, `scripts/`, or examples only.
+
+Recommended temporary layout:
+
+```text
+<skill-root>/skill-workspace/
+  evals.md
+  iteration-1/
+    baseline/
+    with-skill/
+  iteration-2/
+    baseline/
+    with-skill/
+```
+
+A lightweight `evals.md` is enough:
+
+```markdown
+# Evals
+
+## eval-1
+Prompt: ...
+Why it matters: ...
+
+## eval-2
+Prompt: ...
+Why it matters: ...
+```
+
+---
+
+## Phase 5: Run the Comparison
+
+The baseline depends on the situation.
+
+### Baselines
+
+- **New skill**: run the task without the skill
+- **Existing skill improvement**: compare against the old skill version
+- **Port from another harness**: compare the original skill and the Pi-adapted one if both can be exercised meaningfully
+
+### How to run in Pi
+
+If the `agent` tool is available, prefer spawning fresh agents so each run gets a clean context. Use one run per eval prompt for:
+- `baseline`
+- `with-skill`
+
+If `agent` is not available, do the runs inline in separate fresh sessions when possible.
+
+For each run, save:
+- the prompt
+- the resulting output or files
+- a short note on whether the skill triggered and behaved as intended
+
+A simple per-run file is enough:
+
+```markdown
+# eval-1 / with-skill
+
+Prompt: ...
+
+## Outcome
+...
+
+## Notes
+- Triggered correctly? yes/no
+- Main strengths:
+- Main failures:
+```
+
+### What to compare
+
+Look at:
+- did the skill trigger when it should?
+- did it reduce flailing?
+- did it improve output structure or correctness?
+- did it cause unhelpful extra work?
+- did it overfit to one phrasing?
+
+For action skills, also compare:
+- file paths used
+- scripts executed
+- whether it actually completed the task
+
+---
+
+## Phase 6: Analyze and Revise
+
+Revise from evidence, not vibes.
+
+### Common improvement moves
+
+#### 1. Fix triggering
+If the model failed to use the skill, the description is usually the first suspect.
+
+Improve the description by making it clearer about:
+- what the skill does
+- what user language should trigger it
+- what nearby situations also count
+
+#### 2. Remove dead weight
+If the transcript shows the skill causing pointless ceremony, cut it.
+
+Examples:
+- too many required sections in the output
+- long setup text that does not change behavior
+- redundant explanation of obvious concepts
+
+#### 3. Explain the why
+If the model follows instructions mechanically but misses the point, explain the reasoning.
+
+Instead of:
+- “Always include X”
+
+Try:
+- “Include X because without it the next session cannot resume safely”
+
+#### 4. Bundle repeated helpers
+If multiple runs recreate the same helper script or transformation, add a real script under `scripts/` and tell the skill when to use it.
+
+#### 5. Split bulky content
+If the main file is turning into a wall of text, move detail to:
+- `references/`
+- example files
+- templates
+- scripts
+
+---
+
+## Phase 7: Iterate Until It Is Clearly Better
+
+Run another iteration when:
+- the skill improved but still misses obvious cases
+- triggering is still weak
+- the output is inconsistent across prompts
+- the skill is promising but too verbose or too brittle
+
+Stop when:
+- the user is happy
+- the skill beats the baseline on the important prompts
+- further changes are mostly churn
+
+Do not keep iterating just because iteration feels productive.
+
+---
+
+## Pi-Specific Adaptation Notes
+
+When adapting a skill from Anthropic or another harness, keep these Pi realities in mind:
+
+- Pi skills are plain skill directories with `SKILL.md` plus optional files.
+- Progressive disclosure still matters: keep descriptions sharp and main files focused.
+- Some harness-specific frontmatter or execution features may not exist or may behave differently in Pi.
+- Pi is happy with plain files, scripts, and markdown comparisons. You do not need a fancy evaluation UI to improve a skill.
+- If Pi-specific tools exist in this environment, use them. If not, write the workflow so it still works with `read`, `write`, `edit`, and `bash`.
+
+---
+
+## Deliverables
+
+When finishing a skill-creation pass, leave behind:
+
+1. the updated skill directory
+2. notes on what was tested; use an issue comment or chat summary unless the user asks for committed eval artifacts
+3. a concise summary for the user:
+   - what changed
+   - what was tested
+   - what still seems weak
+
+If the work is substantial and the repo has a scratchpad, write a report there.
+
+---
+
+## Gotchas
+
+- Do not overfit to the 2-3 eval prompts that were easiest to inspect.
+- Do not blindly port unsupported features from other harnesses.
+- Do not turn every behavior into a rigid rule; first ask what outcome you actually need.
+- Do not leave the skill untested if it has side effects or workflow complexity.
+- Do not forget that the description is the trigger.
+- Do not commit `skill-workspace/` folders in this repo unless explicitly requested.
+
+---
+
+## See Also
+
+- [[skills/search/SKILL|/search]] — find reference skills, docs, and examples
+- [[skills/report/SKILL|/report]] — capture what changed and why
+- [[skills/visual-explainer/SKILL|/visual-explainer]] — useful for side-by-side eval comparison pages

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: triage
+description: Triage the stfc/goldilocks-data issue board by closing placeholders, folding duplicates, assigning milestones, and keeping one concrete issue per PR or model release. Use when catchup finds board drift.
+argument-hint: [optional scope]
+---
+
+# Triage issues
+
+Use the `github-cli` skill. Inspect before mutating; propose changes to the user
+before closing or restructuring text written by others.
+
+## Inventory
+
+```bash
+gh issue list --repo stfc/goldilocks-data --state open --limit 200 \
+  --json number,title,body,labels,milestone,updatedAt
+gh issue list --repo stfc/goldilocks-data --state closed --limit 100 \
+  --json number,title,closedAt
+gh api repos/stfc/goldilocks-data/milestones
+```
+
+Cross-check open issues against branches, PRs, recent merges, sibling-repository
+dependencies, and the current release milestone.
+
+## Classify
+
+- **Keep:** concrete, shippable, current, correctly scoped, and assigned.
+- **Expand:** valid feature but missing evidence, approach, scientific contract,
+  verification, or acceptance criteria.
+- **Fold:** duplicate, decision, experiment phase, or sub-step of another issue.
+- **Close:** stale placeholder, roadmap mirror, superseded design, completed work,
+  or work outside this repository's boundary.
+
+Distinguish a campaign-operations issue from a package-mechanics issue. A
+campaign issue must name its AiiDA group label, its source set, and the
+convergence criteria it is judged by; without those it is a discussion, not a
+shippable issue. A package issue must name the boundary it changes — codes,
+intents, sweeps, aiida, or analysis — and must not depend on a private CSV or
+CIF path.
+
+## Execute safely
+
+- Comment before closing so the reason and destination are durable.
+- Do not edit or delete text authored by someone else.
+- Every agent-authored comment ends with the required attribution.
+- Assign a milestone to every surviving issue.
+- Do not burst-file replacements; consolidate first.
+
+Finish with a table of kept, expanded, folded, and closed issues plus any
+remaining dependency or milestone mismatch.

--- a/.agents/skills/use-uv/SKILL.md
+++ b/.agents/skills/use-uv/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: use-uv
+description: Use uv for all Python package management in this project. Use when installing deps, running commands, adding packages, building, or any Python environment task. Never use pip, venv, or pipx.
+---
+
+# Use uv
+
+This project uses `uv`. Never use `pip`, `venv`, `pipx`, or `virtualenv`.
+
+## Common commands
+
+```bash
+uv sync --group dev            # install the project with dev deps
+uv sync --group docs           # add the MkDocs dependencies
+uv run pytest                  # run a command in the project environment
+uv run ruff check src tests campaigns/qe/kpoints/scripts   # lint
+uv run python -c "..."         # run one-off python in the project env
+uv add <package>               # add a runtime dependency
+uv add --group dev <package>   # add a dev dependency
+uv build                       # build sdist + wheel
+```
+
+## Why uv
+
+- Faster than pip. Locks are reliable. Virtualenv management is automatic.
+- `uv run` executes in the project's virtualenv without activating it first.
+- Dependencies are declared in `pyproject.toml`. The lock file is `uv.lock`.
+
+## Gotchas
+
+- `uv sync` replaces `pip install -e .` and `pip install -r requirements.txt`.
+- `uv run` replaces `source .venv/bin/activate && ...`. Don't activate venvs manually.
+- To add a dependency, edit `pyproject.toml` or use `uv add`. Don't `pip install` — it won't survive a sync.
+- If `uv sync` fails, read the error. It's usually a version conflict in `pyproject.toml`.
+
+## Extras
+
+AiiDA and pymatgen are optional extras, not default dependencies. Campaign
+scripts need them explicitly:
+
+```bash
+uv run --extra aiida --extra kmesh python campaigns/qe/kpoints/scripts/monitor.py --once --cif-dir /path/to/CIF_files
+```
+
+`uv sync --group dev` alone does not install them, so an AiiDA import error
+usually means a missing `--extra`, not a broken environment.

--- a/.agents/skills/write-a-test/SKILL.md
+++ b/.agents/skills/write-a-test/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: write-a-test
+description: Write tests for goldilocks-data. Use when adding or extending test coverage, after fixing a bug, or when capturing discovered behaviour.
+---
+
+# Write a Test
+
+## Runner
+
+Use `pytest` directly. No `tox`, no `nox`.
+
+```bash
+uv run pytest                          # all tests
+uv run pytest tests/test_kmesh.py      # one file
+uv run pytest -k "test_entry"          # by name
+```
+
+## Coverage
+
+Use coverage reports when adding baseline tests, refactoring public behaviour, or checking whether a new test actually exercises the intended path.
+
+```bash
+uv run --with pytest-cov pytest --cov=goldilocks_data --cov-report=term-missing
+uv run --with pytest-cov pytest --cov=goldilocks_data --cov-report=xml
+uv run --with pytest-cov pytest --cov=goldilocks_data --cov-report=html
+```
+
+- `uv run --with pytest-cov` keeps coverage tooling available without adding a permanent dependency unless the project decides it wants one.
+- `term-missing` is useful during development because it shows uncovered lines in the terminal.
+- `xml` is useful for CI services such as Codecov or Coveralls if/when they are configured.
+- `html` is useful for local inspection in a browser.
+
+New tests should not reduce overall coverage. Do not chase coverage numbers by testing implementation trivia; prioritize public behaviour, scientific edge cases, and regressions.
+
+## Portability
+
+Tests must not depend on `local_data/` or any private dataset. The test suite must pass from a clean checkout with only `uv sync --group dev`.
+
+- Use `pytest`'s `tmp_path` fixture for any file output.
+- Build synthetic fixtures inline or via helpers: pymatgen `Structure` objects, constructed dataclass instances, small UPF snippets as strings.
+- If you need a structure, use `pymatgen.core.Structure.from_spacegroup()` or construct a simple cubic cell — don't reach for a CIF file.
+
+## When to write one
+
+- **After fixing a bug** — write the test that would have caught it.
+- **After adding a public function or type** — at minimum a construction/smoke test.
+- **Before moving on from exploration** — if you ran something interactively and it revealed important behaviour, capture it as a regression test before you forget the details.
+
+## Naming and location
+
+- Test files: `tests/test_<module>.py`.
+- Test functions: `test_<behaviour_description>` — describe what's being verified, not what the function is called.
+- Bad: `test_kmesh_entry` — what about it?
+- Good: `test_kmesh_entry_index_starts_at_one`
+
+## What to test
+
+- Public API surface. Internal functions only if they have non-obvious invariants.
+- Edge cases that the happy path won't catch: empty inputs, single-element structures, boundary values.
+- Error paths — verify the right exception type and message, not just that it raises.

--- a/.agents/skills/write-docs/SKILL.md
+++ b/.agents/skills/write-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: write-docs
+description: Write or update goldilocks-data documentation. Use when changing README.md, the MkDocs site under docs/, campaign READMEs, or the mkdocs.yml nav.
+---
+
+# Write Docs
+
+Use this skill for project documentation changes.
+
+## Goals
+
+- Keep docs current with the branch.
+- Prefer terse, direct wording.
+- Document actual behaviour only. Do not describe a planned CLI or API as implemented.
+- Keep one canonical API path. Do not add compatibility notes unless backward compatibility was explicitly requested.
+
+## Files
+
+- `README.md` — repository map, the package/campaign boundary, submit and cleanup examples, development commands.
+- `docs/` — the published MkDocs site, at <https://stfc.github.io/goldilocks-data/>:
+
+  ```text
+  docs/index.md                    what the repository does, where to go
+  docs/installation/               environment setup (AiiDA on macOS, QE on SCARF)
+  docs/campaigns/                  one page per campaign, organised by code then task
+  docs/results.md                  how to use the exported records
+  docs/reference/repository.md     repository layout
+  docs/reference/convergence.md    the convergence criteria
+  ```
+
+- `campaigns/<code>/<task>/README.md` — plugin setup, campaign settings, analysis, result snapshot.
+- `AGENTS.md` — durable project rules for future agents.
+
+A new page must be added to the `nav` in `mkdocs.yml`, or `--strict` fails the build.
+
+## Workflow
+
+1. Check the current code before writing.
+
+   ```bash
+   find src/goldilocks_data -maxdepth 2 -type f | sort
+   rg "def |class " src/goldilocks_data tests
+   rg "project.scripts" -A3 pyproject.toml
+   ```
+
+2. Keep the package/campaign boundary straight. The package owns reusable
+   mechanics; notebooks and campaign scripts own dataset-specific decisions —
+   private CSV paths, local CIF directories, which `source_db_id` values belong
+   in a batch. Do not document a private path as part of the package API.
+
+3. Keep package ownership consistent.
+
+   ```text
+   codes/      -> DFT code identifiers
+   intents/    -> calculation intent identifiers
+   sweeps/     -> SweepPoint, AiidaJobSpec, kmesh/kindex helpers
+   aiida/      -> submit orchestration, registry, cleanup, builder adapters
+   analysis/   -> convergence and result analysis
+   cli.py      -> thin command wrappers
+   ```
+
+4. Run checks before committing.
+
+   ```bash
+   uv run ruff check src tests campaigns/qe/kpoints/scripts
+   uv run ruff format --check src tests campaigns/qe/kpoints/scripts
+   uv run pytest -q
+   uv sync --group docs && uv run mkdocs build --strict
+   ```
+
+## Style
+
+- Be terse.
+- Use short sections.
+- Use examples over prose.
+- Avoid roadmap promises in user-facing docs.
+- If something is future work, say `not implemented yet`.
+- Do not use flowery language.
+
+## Common mistakes
+
+- Documenting a planned CLI command as a current one. The only console script is
+  `goldilocks-data`.
+- Adding a page without adding it to the `mkdocs.yml` nav, which breaks
+  `mkdocs build --strict`.
+- Writing a private CSV or CIF path into package documentation.
+- Claiming builder support beyond QE `pw.x` SCF.
+- Adding compatibility aliases or migration paths without an explicit request.

--- a/.claude/skills/catchup
+++ b/.claude/skills/catchup
@@ -1,0 +1,1 @@
+../../.agents/skills/catchup

--- a/.claude/skills/dft-basics
+++ b/.claude/skills/dft-basics
@@ -1,0 +1,1 @@
+../../.agents/skills/dft-basics

--- a/.claude/skills/github-cli
+++ b/.claude/skills/github-cli
@@ -1,0 +1,1 @@
+../../.agents/skills/github-cli

--- a/.claude/skills/make-a-pr
+++ b/.claude/skills/make-a-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/make-a-pr

--- a/.claude/skills/plan
+++ b/.claude/skills/plan
@@ -1,0 +1,1 @@
+../../.agents/skills/plan

--- a/.claude/skills/report
+++ b/.claude/skills/report
@@ -1,0 +1,1 @@
+../../.agents/skills/report

--- a/.claude/skills/review
+++ b/.claude/skills/review
@@ -1,0 +1,1 @@
+../../.agents/skills/review

--- a/.claude/skills/skill-creator
+++ b/.claude/skills/skill-creator
@@ -1,0 +1,1 @@
+../../.agents/skills/skill-creator

--- a/.claude/skills/triage
+++ b/.claude/skills/triage
@@ -1,0 +1,1 @@
+../../.agents/skills/triage

--- a/.claude/skills/use-uv
+++ b/.claude/skills/use-uv
@@ -1,0 +1,1 @@
+../../.agents/skills/use-uv

--- a/.claude/skills/write-a-test
+++ b/.claude/skills/write-a-test
@@ -1,0 +1,1 @@
+../../.agents/skills/write-a-test

--- a/.claude/skills/write-docs
+++ b/.claude/skills/write-docs
@@ -1,0 +1,1 @@
+../../.agents/skills/write-docs

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,8 @@
 *.py[cod]
 .ipynb_checkpoints/
 
-# Local agent/session files
-.agents/
-AGENTS.md
+# Agent configuration is committed: .agents/ is the shared source and
+# .claude/skills symlinks to it. CLAUDE.md stays local.
 CLAUDE.md
 
 # Historical working copies remain local; the curated notebook lives beside them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# goldilocks-data
+
+The execution and analysis layer around AiiDA-backed DFT campaigns.
+
+## What goldilocks-data Does
+
+Three jobs, in order:
+
+1. **Generate** — submit parameter sweeps through AiiDA with stable structure
+   identifiers and calculation provenance.
+2. **Analyse** — apply explicit convergence criteria and find the smallest
+   acceptable input for each structure.
+3. **Publish** — export documented snapshots for research and model training.
+
+AiiDA is the only execution engine. The extensible axes are:
+
+- **code**: `qe`, `vasp`, `cp2k`, `castep`
+- **intent**: `scf`, `nscf`, `relax`, `phonon`, `md`, `tddft`, `dft_u`
+- **sweep axis**: `kindex`, `pp`, `code`, `spin_type`, `nspin`, `magneticity`,
+  `soc`, `smearing`, `cutoff`
+
+Current builder support is QE `pw.x` SCF. Submit orchestration is already
+generic: a new code or intent adds an AiiDA builder adapter and registers it by
+`(DftCode, CalculationIntent)`.
+
+## Ecosystem Position
+
+`goldilocks-data` → `goldilocks-ml` → `goldilocks-core`
+
+- **goldilocks-data** produces convergence records from real calculations
+- **goldilocks-ml** trains models on those records and publishes versioned artefacts
+- **goldilocks-core** loads those artefacts and recommends inputs to end users
+
+Model training does not belong here. End-user input generation does not belong
+here.
+
+## The Boundary That Matters
+
+The package owns **reusable mechanics**:
+
+- gamma-inclusive kindex schedules
+- explicit `source_db_id + structure + sweep points` AiiDA submission
+- AiiDA group/extras de-duplication
+- persistent failed-source records
+- convergence labelling from finished energies
+- finished remote-folder cleanup
+
+Notebooks and campaign scripts own **dataset-specific decisions**:
+
+- reading private CSV files
+- reading local CIF directories
+- deciding which `source_db_id` values belong in a batch
+- translating historical convergence rows into a new `kindex_max`
+
+A private path must never reach the package API.
+
+## Layout
+
+```text
+campaigns/<code>/<task>/   setup, scripts, notebook, result snapshot
+src/goldilocks_data/
+  codes/                   DFT code identifiers
+  intents/                 calculation intent identifiers
+  sweeps/                  SweepPoint, AiidaJobSpec, kmesh/kindex helpers
+  aiida/                   submit orchestration, registry, cleanup, builders
+  analysis/                convergence and result analysis
+  cli.py                   thin command wrappers
+docs/                      the published MkDocs site
+```
+
+## The k-index Convention
+
+`k_index` is **0-based**, and rung 0 is the Γ-only `(1, 1, 1)` mesh. Each step up
+is the next denser mesh the reciprocal lattice admits.
+
+The ladder is built from the k-distances at which `ceil(|b_i| / k_distance)`
+changes on any axis — that is, from `|b_i| / n`. The enumeration cap on `n` is
+applied per axis, so axes with different `|b_i|` exhaust their breakpoints at
+different k-distances: the ladder is a complete set of meshes only for
+`k_distance >= max(|b_i|) / n_max`, and below that it silently skips reachable
+meshes. Any recomputation or published `k_index` column must state the cap it
+used.
+
+This convention is shared with `goldilocks-core`. Changing it invalidates every
+`k_index` value already recorded or trained on.
+
+## Commands
+
+```bash
+uv sync --group dev                                        # install with dev deps
+uv run pytest                                              # run tests
+uv run ruff check src tests campaigns/qe/kpoints/scripts   # lint
+uv run ruff format src tests campaigns/qe/kpoints/scripts  # format
+
+uv sync --group docs && uv run mkdocs build --strict       # build the docs site
+```
+
+Campaign scripts need the optional extras explicitly:
+
+```bash
+uv run --extra aiida --extra kmesh python campaigns/qe/kpoints/scripts/monitor.py --once --cif-dir /path/to/CIF_files
+```
+
+Use `uv`, not `pip`.
+
+## Code Style
+
+- Ruff with `E`, `F`, `I` rules. Target Python 3.12.
+- `from __future__ import annotations` at the top of every module.
+- Dataclasses use `slots=True`. Frozen for immutable value objects.
+- Domain modules, not generic buckets: no `helpers/`, no `utils/`, no `processing/`.
+- Prefer one clear API over compatibility shims. Do not add legacy aliases,
+  duplicate import paths, or wrapper modules unless the user explicitly asks
+  for backward compatibility.
+- `snake_case` for everything. No `CamelCase` except in string literals matching
+  external formats.
+- Type hints on public API surfaces. Internal functions can be looser.
+- Docstrings: factual — what it does, what it returns, what it assumes.
+
+## Tests
+
+Tests live flat in `tests/`, one module per boundary. Prioritise scientific
+behaviour over line coverage: a test that pins a convergence label or a kindex
+schedule is worth more than one that exercises a wrapper.
+
+## What Doesn't Belong Here
+
+- Model training — that is goldilocks-ml.
+- End-user input recommendation — that is goldilocks-core.
+- AiiDA workflows for other people's campaigns, scheduler scripts.
+- Jupyter notebooks — `notebooks/` is gitignored. Convert insights into tests.
+- Large data or pseudo libraries. Private CSV and CIF paths stay outside the repo.
+
+## Rules
+
+- **Never push or merge directly to `main`.** All changes arrive through PRs.
+- Every PR must close an issue (`Closes #N`).
+- Track work status in GitHub Issues/PRs.
+- Any GitHub issue, issue comment, PR description, or review comment written by
+  an agent must explicitly say so and name the human it represents:
+  `Written by an agent on behalf of <user>.`
+
+## Agent Workflow
+
+Skills are in `.agents/skills/`, and `.claude/skills/` symlinks to them so Claude
+Code and Codex read the same files: `catchup`, `plan`, `triage`, `review`,
+`report`, `make-a-pr`, `write-a-test`, `write-docs`, `use-uv`, `dft-basics`,
+`github-cli`, `skill-creator`.
+
+- Start sustained work with `catchup`.
+- Use `plan` for multi-step changes; keep the issue body as the current plan.
+- Use `triage` when the issue board has drifted.
+- Use `review` before PRs or after substantial changes.
+- Use `report` for handoff/progress comments.
+- Use `make-a-pr` only after implementation, tests, and review are ready.


### PR DESCRIPTION
Commits an agent configuration written for this repository, and stops
gitignoring it.

`goldilocks-ml` and `goldilocks-core` both commit `.agents/` and `AGENTS.md`;
this repository listed them in `.gitignore`, so anyone other than the original
developer — and any agent — started here with no project instructions and no
skills.

## The local copy could not be committed as-is

It was a half-adapted copy of goldilocks-core's configuration:

| File | Problem |
| --- | --- |
| `AGENTS.md` | opened with `# goldilocks-core` and described core's `Load → Analyse → Advise → Select → Generate` pipeline, which does not exist here |
| `github-cli/SKILL.md` | hard-coded `--repo stfc/goldilocks-core` in ~15 commands, so an agent files issues against the wrong repository |
| `catchup/SKILL.md` | same, in 4 commands |
| `write-a-test/SKILL.md` | ran coverage as `--cov=goldilocks_core` |
| `write-docs/SKILL.md` | inspected `src/goldilocks_core`, referenced `docs/architecture.md` (absent), documented a `goldilocks-kmesh` CLI (the console script is `goldilocks-data`), and invoked a mermaid validator at `/home/sigil/.pi/...` |
| `dft-basics/SKILL.md` | described itself as being for goldilocks-core |

## What is here

**`AGENTS.md`** — written for goldilocks-data: the generate/analyse/publish
sequence, ecosystem position, the package/campaign boundary ("a private path
must never reach the package API"), the real layout, and the commands from
`README.md` including `ruff check src tests campaigns/qe/kpoints/scripts` and
the `--extra aiida --extra kmesh` campaign invocation.

It also records **the k-index convention**, which cost real effort to establish:
`k_index` is 0-based with rung 0 the Γ-only `(1, 1, 1)` mesh; the ladder comes
from the k-distances where `ceil(|b_i| / k_distance)` changes; and the
enumeration cap on `n` is applied *per axis*, so the ladder is a complete set of
meshes only for `k_distance >= max(|b_i|) / n_max` and silently skips reachable
meshes below that. Any recomputed or published `k_index` column must state the
cap it used.

**`.agents/skills/`** — 12 skills, every goldilocks-core reference corrected.
`write-docs` is rewritten against the real docs tree and now warns that a new
page must be added to the `mkdocs.yml` nav or `--strict` fails. `use-uv` gains
an Extras section: AiiDA and pymatgen are optional extras, so an AiiDA import
error usually means a missing `--extra`, not a broken environment. `triage` is
ported from goldilocks-ml with its ML-specific classification rule replaced by
a campaign/package one.

**`.claude/skills/<name>`** — relative symlinks to `../../.agents/skills/<name>`,
stored as git mode `120000`, the mechanism goldilocks-ml uses. Codex reads
`AGENTS.md` and `.agents/`; Claude Code discovers `.claude/skills/`; both read
the same files, so they cannot drift.

No `CLAUDE.md` — neither sibling repository has one, and `.gitignore` still
excludes it. The existing local one pulled all twelve `SKILL.md` files into
every session's context through `@` imports; the symlinks do the same job
without that cost.

## Verification

- No `goldilocks-core` / `goldilocks_core` / `goldilocks-kmesh` reference and no
  foreign absolute path survives, except two deliberate ecosystem
  cross-references in `AGENTS.md`
- All 12 skills have a matching symlink, and all 12 resolve to a `SKILL.md`
- No code, test, or packaging file is touched

Closes #23

---
Written by an agent on behalf of @junwen94.
