### PR TITLE
fix(kmesh): align the ladder with core, and keep the dedup core lacks

### DIFF
--- a/src/goldilocks_data/sweeps/kmesh.py
+++ b/src/goldilocks_data/sweeps/kmesh.py
@@ -30,11 +30,27 @@ def k_distance_to_mesh(structure: Any, k_distance: float) -> tuple[int, int, int
     return tuple(max(1, math.ceil(round(length / k_distance, 5))) for length in lengths)
 
 
-def generate_candidate_k_distances(structure: Any, max_index: int = 30) -> list[float]:
-    """Generate spacing boundaries that can change at least one mesh axis."""
+def generate_candidate_k_distances(structure: Any, max_kpoints_per_axis: int = 50) -> list[float]:
+    """Return the k-distances at which any axis changes its k-point count.
+
+    ``mesh_i = ceil(|b_i| / k_distance)`` steps from ``n`` to ``n + 1`` exactly at
+    ``k_distance = |b_i| / n``, so those quotients are the only distances where
+    the mesh can change.
+
+    ``max_kpoints_per_axis`` bounds ``n`` — how many k-points per axis are
+    enumerated. It is *not* a bound on the number of rungs, which is roughly the
+    number of distinct axis lengths times the bound. Because the bound applies
+    per axis and the axes have different ``|b_i|``, they exhaust their quotients
+    at different distances: the returned list is a complete set of change points
+    only down to ``max(|b_i|) / max_kpoints_per_axis``. See
+    ``build_gamma_kmesh_entries`` for what that implies.
+    """
 
     lengths = _reciprocal_lengths(structure)
-    return sorted({round(length / index, 8) for length in lengths for index in range(1, max_index + 1)}, reverse=True)
+    return sorted(
+        {round(length / index, 8) for length in lengths for index in range(1, max_kpoints_per_axis + 1)},
+        reverse=True,
+    )
 
 
 def mesh_to_k_line_density_interval(structure: Any, mesh: tuple[int, int, int]) -> tuple[float, float]:
@@ -60,10 +76,25 @@ def _n_reduced_kpoints(structure: Any, mesh: tuple[int, int, int]) -> int:
         return full_mesh_size
 
 
-def build_gamma_kmesh_entries(structure: Any, max_candidate_index: int = 30) -> list[KMeshEntry]:
-    """Build distinct unshifted, Gamma-inclusive k-mesh entries for a structure."""
+def build_gamma_kmesh_entries(structure: Any, max_kpoints_per_axis: int = 50) -> list[KMeshEntry]:
+    """Build the unshifted, Gamma-inclusive k-mesh ladder for a structure.
 
-    candidates = generate_candidate_k_distances(structure, max_candidate_index)
+    ``kindex`` is 0-based and rung 0 is the Gamma-only ``(1, 1, 1)`` mesh, which
+    the first probe always yields because it sits above every ``|b_i|``.
+
+    The ladder is complete and non-repeating:
+
+    * It stops at the first rung where an axis count would rise by more than one.
+      Once the longest axis has used up its enumerated quotients its count keeps
+      rising with no candidate marking the change, so adjacent candidates span
+      several meshes and probing the midpoint keeps only one of them. A jump
+      greater than one is exactly that condition.
+    * It skips a mesh already on the ladder. Axes with equal ``|b_i|`` share
+      their change points, so two consecutive intervals can yield the same mesh;
+      without this, two ``kindex`` values would name one mesh.
+    """
+
+    candidates = generate_candidate_k_distances(structure, max_kpoints_per_axis)
     if not candidates:
         return []
 
@@ -73,7 +104,11 @@ def build_gamma_kmesh_entries(structure: Any, max_candidate_index: int = 30) -> 
 
     entries: list[KMeshEntry] = []
     seen: set[tuple[int, int, int]] = set()
+    previous: tuple[int, int, int] | None = None
     for mesh, interval in intervals:
+        if previous is not None and any(now - before > 1 for before, now in zip(previous, mesh, strict=True)):
+            break
+        previous = mesh
         if mesh in seen:
             continue
         seen.add(mesh)

--- a/tests/test_kmesh.py
+++ b/tests/test_kmesh.py
@@ -40,7 +40,7 @@ def test_gamma_kmesh_entries_start_with_gamma_mesh() -> None:
         natoms=4,
     )
 
-    entries = build_gamma_kmesh_entries(structure, max_candidate_index=4)
+    entries = build_gamma_kmesh_entries(structure, max_kpoints_per_axis=4)
 
     assert entries[0].kindex == 0
     assert entries[0].mesh == (1, 1, 1)
@@ -69,8 +69,59 @@ def test_entry_payload_serializes_infinite_right_bound_as_none() -> None:
         natoms=2,
     )
 
-    payload = entry_payload(build_gamma_kmesh_entries(structure, max_candidate_index=2)[0])
+    payload = entry_payload(build_gamma_kmesh_entries(structure, max_kpoints_per_axis=2)[0])
 
     assert payload["kindex"] == 0
     assert payload["k_mesh"] == (1, 1, 1)
     assert payload["k_dist_right"] is None
+
+
+def _structure(a: float, b: float, c: float, natoms: int = 1) -> Structure:
+    return Structure(
+        lattice=Lattice(
+            reciprocal_lattice=Reciprocal(a, b, c),
+            reciprocal_lattice_crystallographic=Reciprocal(a / 5, b / 5, c / 5),
+        ),
+        natoms=natoms,
+    )
+
+
+def test_ladder_never_skips_a_reachable_mesh() -> None:
+    # An anisotropic cell: the long axes exhaust their change points while the
+    # short one is still stepping, which is where an unbounded ladder starts
+    # jumping several meshes at once.
+    entries = build_gamma_kmesh_entries(_structure(2.5547, 2.5547, 0.6485), max_kpoints_per_axis=30)
+    meshes = [entry.mesh for entry in entries]
+
+    assert len(meshes) > 1
+    for before, after in zip(meshes[:-1], meshes[1:], strict=True):
+        steps = [now - previous for previous, now in zip(before, after, strict=True)]
+        assert max(steps) == 1, f"{before} -> {after} skips a mesh"
+        assert min(steps) >= 0, f"{before} -> {after} is not monotonic"
+
+
+def test_ladder_never_repeats_a_mesh_for_degenerate_axes() -> None:
+    # MC3D 170541 (SiO2): |b_1| and |b_3| are exactly equal, so their change
+    # points coincide and two consecutive intervals yield the same mesh. Without
+    # the skip, two kindex values would name one mesh.
+    meshes = [entry.mesh for entry in build_gamma_kmesh_entries(_structure(0.701, 0.7816, 0.701))]
+
+    assert len(meshes) == len(set(meshes))
+    assert meshes[:4] == [(1, 1, 1), (1, 2, 1), (2, 2, 2), (2, 3, 2)]
+
+
+def test_raising_the_axis_bound_only_extends_the_ladder() -> None:
+    # kindex is recorded in campaign snapshots and published records, so a
+    # larger enumeration must never renumber a rung that already existed.
+    structure = _structure(2.5547, 2.5547, 0.6485)
+    short = [entry.mesh for entry in build_gamma_kmesh_entries(structure, max_kpoints_per_axis=20)]
+    long = [entry.mesh for entry in build_gamma_kmesh_entries(structure, max_kpoints_per_axis=60)]
+
+    assert len(long) > len(short)
+    assert long[: len(short)] == short
+
+
+def test_kindex_is_contiguous_and_zero_based() -> None:
+    entries = build_gamma_kmesh_entries(_structure(0.701, 0.7816, 0.701))
+
+    assert [entry.kindex for entry in entries] == list(range(len(entries)))


### PR DESCRIPTION
goldilocks-core is renaming its per-axis bound to max_kpoints_per_axis, defaulting it to 50, and truncating the ladder at the first rung where an axis count would rise by more than one. Adopt both here, so the two ladders do not diverge again.

Do not adopt core's lack of dedup. For a structure with degenerate reciprocal axes two consecutive candidate intervals can yield the same mesh - MC3D 170541 (SiO2) has |b| = [0.701, 0.7816, 0.701], and without the skip rungs 1 and 2 are both (1, 2, 1). Two kindex values naming one mesh contradicts 'each step up is the next denser mesh'. Over 4,000 structures 64.6% have two or more equal |b_i| and 0.2% actually repeat, and when they do the median first repeat is rung 2 - where the recorded data sits. Dropping dedup to match core exactly would move 98 of 79,885 recorded kindex values onto a different mesh.

Lossless for recorded data: recomputing all five kindex columns of campaigns/qe/kpoints/results/source-summary.csv (16,208 structures, 79,885 values) with dedup kept, bound 50 and truncation gives 79,885 identical, 0 different, 0 outside the ladder.

The ladder is about 35% longer than before, and build_gamma_kmesh_entries computes n_reduced_kpoints per rung through spglib, so it is slower. The eager symmetry reduction is worth revisiting separately - kindex_points only ever uses a slice of the ladder.

Closes #28