### PR TITLE
refactor(kmesh): number the k-mesh ladder from 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,12 @@ docs/                      the published MkDocs site
 
 ## The k-index Convention
 
-`k_index` is **0-based**, and rung 0 is the Γ-only `(1, 1, 1)` mesh. Each step up
+`k_index` is **1-based**, and rung 1 is the Γ-only `(1, 1, 1)` mesh. Each step up
 is the next denser mesh the reciprocal lattice admits.
+
+Record `d5ds2-64f16` was published before this and is 0-based. A published
+record keeps the convention it was published with, so a consumer must read the
+base from the record rather than assume it.
 
 The ladder is built from the k-distances at which `ceil(|b_i| / k_distance)`
 changes on any axis — that is, from `|b_i| / n`. The enumeration cap on `n` is

--- a/docs/published-records.md
+++ b/docs/published-records.md
@@ -30,9 +30,16 @@ have a structure file and no converged answer.
 
 ### The k_index in this record
 
-`k_index` is **0-based, with rung 0 the gamma-only `(1, 1, 1)` mesh**, and was
-computed with a per-axis enumeration bound of **50**, the ladder truncated at
-the first rung where an axis count would rise by more than one.
+`k_index` in this record is **0-based, with rung 0 the gamma-only `(1, 1, 1)`
+mesh**, and was computed with a per-axis enumeration bound of **50**, the ladder
+truncated at the first rung where an axis count would rise by more than one.
+
+!!! warning "This record is 0-based; the convention since is 1-based"
+
+    Everything produced after this record numbers the same ladder from 1, so
+    rung *n* here is rung *n + 1* under the current convention. The published
+    record is not rewritten: it keeps the convention it was published with, and
+    a consumer reads the base from the record rather than assuming it.
 
 That bound is part of the definition, not an implementation detail. The change
 points of the ladder are `|b_i| / n`, the bound applies per axis, and axes with

--- a/docs/reference/kmesh.md
+++ b/docs/reference/kmesh.md
@@ -29,8 +29,11 @@ same scale.
 
 ## `kindex`
 
-The rung's position, **0-based**, with rung 0 the Γ-only `(1, 1, 1)` mesh. Each
+The rung's position, **1-based**, with rung 1 the Γ-only `(1, 1, 1)` mesh. Each
 step up is the next denser mesh the reciprocal lattice admits.
+
+Record `d5ds2-64f16` predates this convention and is 0-based; see
+[published records](../published-records.md).
 
 `kindex` only means something together with the enumeration bound that built the
 ladder — see [the ladder](#the-ladder) below.

--- a/src/goldilocks_data/sweeps/kindex.py
+++ b/src/goldilocks_data/sweeps/kindex.py
@@ -5,11 +5,16 @@ from goldilocks_data.sweeps.models import SweepAxis, SweepPoint
 
 
 def kindex_points(structure: object, kindex_min: int, kindex_max: int) -> tuple[SweepPoint, ...]:
-    """Build explicit sweep points for a gamma-inclusive kindex range."""
+    """Build explicit sweep points for a gamma-inclusive kindex range.
+
+    ``kindex_min`` and ``kindex_max`` are rungs, not list positions: rung 1 is
+    the Gamma-only mesh and lives at index 0.
+    """
 
     entries = build_gamma_kmesh_entries(structure)
+    selected = [entry for entry in entries if int(kindex_min) <= entry.kindex <= int(kindex_max)]
     points: list[SweepPoint] = []
-    for entry in entries[int(kindex_min) : int(kindex_max) + 1]:
+    for entry in selected:
         points.append(
             SweepPoint(
                 axis_values={SweepAxis.KINDEX.value: int(entry.kindex)},

--- a/src/goldilocks_data/sweeps/kmesh.py
+++ b/src/goldilocks_data/sweeps/kmesh.py
@@ -79,8 +79,10 @@ def _n_reduced_kpoints(structure: Any, mesh: tuple[int, int, int]) -> int:
 def build_gamma_kmesh_entries(structure: Any, max_kpoints_per_axis: int = 50) -> list[KMeshEntry]:
     """Build the unshifted, Gamma-inclusive k-mesh ladder for a structure.
 
-    ``kindex`` is 0-based and rung 0 is the Gamma-only ``(1, 1, 1)`` mesh, which
-    the first probe always yields because it sits above every ``|b_i|``.
+    ``kindex`` is 1-based and rung 1 is the Gamma-only ``(1, 1, 1)`` mesh, which
+    the first probe always yields because it sits above every ``|b_i|``. The
+    rung therefore counts k-points on the densest axis of the coarsest mesh it
+    could be: rung n is reached when some axis first needs n k-points.
 
     The ladder is complete and non-repeating:
 
@@ -118,7 +120,7 @@ def build_gamma_kmesh_entries(structure: Any, max_kpoints_per_axis: int = 50) ->
             line_interval = None
         entries.append(
             KMeshEntry(
-                kindex=len(entries),
+                kindex=len(entries) + 1,
                 mesh=mesh,
                 k_distance_interval=interval,
                 k_line_density_interval=line_interval,

--- a/tests/test_kmesh.py
+++ b/tests/test_kmesh.py
@@ -42,9 +42,9 @@ def test_gamma_kmesh_entries_start_with_gamma_mesh() -> None:
 
     entries = build_gamma_kmesh_entries(structure, max_kpoints_per_axis=4)
 
-    assert entries[0].kindex == 0
+    assert entries[0].kindex == 1
     assert entries[0].mesh == (1, 1, 1)
-    assert entries[1].kindex == 1
+    assert entries[1].kindex == 2
     assert entries[0].k_pra == 4.0
 
 
@@ -71,7 +71,7 @@ def test_entry_payload_serializes_infinite_right_bound_as_none() -> None:
 
     payload = entry_payload(build_gamma_kmesh_entries(structure, max_kpoints_per_axis=2)[0])
 
-    assert payload["kindex"] == 0
+    assert payload["kindex"] == 1
     assert payload["k_mesh"] == (1, 1, 1)
     assert payload["k_dist_right"] is None
 
@@ -121,7 +121,7 @@ def test_raising_the_axis_bound_only_extends_the_ladder() -> None:
     assert long[: len(short)] == short
 
 
-def test_kindex_is_contiguous_and_zero_based() -> None:
+def test_kindex_is_contiguous_and_one_based() -> None:
     entries = build_gamma_kmesh_entries(_structure(0.701, 0.7816, 0.701))
 
-    assert [entry.kindex for entry in entries] == list(range(len(entries)))
+    assert [entry.kindex for entry in entries] == list(range(1, len(entries) + 1))

--- a/tests/test_sweep_models.py
+++ b/tests/test_sweep_models.py
@@ -37,11 +37,11 @@ def test_kindex_points_are_generic_sweep_points() -> None:
         )
     )
 
-    points = kindex_points(structure, 0, 1)
+    points = kindex_points(structure, 1, 2)
 
-    assert points[0].axis_values == {SweepAxis.KINDEX.value: 0}
+    assert points[0].axis_values == {SweepAxis.KINDEX.value: 1}
     assert points[0].k_mesh == (1, 1, 1)
-    assert points[0].extras["kindex"] == 0
+    assert points[0].extras["kindex"] == 1
 
 
 def test_aiida_job_spec_keeps_code_and_intent_separate_from_sweep_axis() -> None:


### PR DESCRIPTION
Rung 0 numbered the Γ-only mesh, which made the rung an offset rather than a count and put every consumer one step away from the natural reading. Rung n now means the coarsest mesh whose densest axis carries n k-points, so rung 1 is Γ-only and the number says what it is.

`kindex_points` selected its range by list position, which was the same thing while the ladder was 0-based and is not any more; it now filters on the rung.

Record d5ds2-64f16 is published and 0-based, and is not rewritten. A published record keeps the convention it carried, so `published-records.md` states the base explicitly and warns that rung n there is rung n+1 here. Consumers read the base from the record rather than assuming one.