### PR TITLE
docs: stop documenting the superseded d5ds2-64f16 record

### DIFF
--- a/docs/published-records.md
+++ b/docs/published-records.md
@@ -26,59 +26,13 @@ agree within **1 meV per atom**. Energy only — no force criterion.
 | `convergence_summary.csv` | 17,757 rows: `source_db_id`, `k_index`, `k_dist_interval`, `k_mesh` |
 | `CIF_files.tar.gz` | 18,220 structures, `CIF_files/<source_db_id>.cif` |
 
-`k_index` here needs both its base and its floor to mean anything; the record's
-`README.md` and `manifest.json` carry both. It supersedes `d5ds2-64f16` below,
-which is 0-based and used a per-axis enumeration bound of 50.
-
-See [convergence criteria](reference/convergence.md) for how labels are assigned,
-and the record's own `README.md` for the full definition and reproduction code.
-
-## Quantum ESPRESSO no-spin SCF calculations (SSSP, k-index) — superseded
-
-[`d5ds2-64f16`](https://data-collections.psdi.ac.uk/records/d5ds2-64f16) · v1 ·
-CC BY 4.0
-
-Superseded by [`52713-55d86`](https://data-collections.psdi.ac.uk/records/52713-55d86)
-above; kept for citations that already reference it. The record is not rewritten.
-
-The converged k-point mesh for 17,757 MC3D structures. No spin polarisation,
-SSSP PBEsol pseudopotentials, every mesh unshifted and therefore
-gamma-inclusive.
-
-Convergence is the first of three consecutive k-distances whose total energies
-agree within **1 meV per atom**. Energy only — no force criterion.
-
-| File | Contents |
-| --- | --- |
-| `convergence_summary.csv` | 17,757 rows: `source_db_id`, `k_index`, `k_dist_interval`, `k_mesh` |
-| `CIF_files.tar.gz` | 18,220 structures, `CIF_files/<source_db_id>.cif` |
-
 The archive carries more structures than the table has rows: 463 structures were
 calculated but never met the criterion within the range of meshes swept, so they
 have a structure file and no converged answer.
 
-### The k_index in this record
-
-`k_index` in this record is **0-based, with rung 0 the gamma-only `(1, 1, 1)`
-mesh**, and was computed with a per-axis enumeration bound of **50**, the ladder
-truncated at the first rung where an axis count would rise by more than one.
-
-!!! warning "This record is 0-based; the convention since is 1-based"
-
-    Everything produced after this record numbers the same ladder from 1, so
-    rung *n* here is rung *n + 1* under the current convention. The published
-    record is not rewritten: it keeps the convention it was published with, and
-    a consumer reads the base from the record rather than assuming it.
-
-That bound is part of the definition, not an implementation detail. The change
-points of the ladder are `|b_i| / n`, the bound applies per axis, and axes with
-different `|b_i|` exhaust their change points at different k-distances — so the
-ladder is a complete set of meshes only down to `max(|b_i|) / 50`. Below that a
-reachable mesh can be skipped. Any recomputation must state the bound it used or
-its `k_index` values are not comparable with these.
-
-Raising the bound only appends rungs and never renumbers an existing one, so
-these values stay valid under a larger enumeration.
+`k_index` needs both its base and its floor to mean anything; the record's
+`README.md` and `manifest.json` carry both, and a consumer reads them from there
+rather than assuming.
 
 See [convergence criteria](reference/convergence.md) for how labels are assigned,
 and the record's own `README.md` for the full definition and reproduction code.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -49,7 +49,7 @@ convention a consumer must share are required fields:
   "rows": 17757,
   "columns": [{"name": "k_index", "dtype": "int", "description": "..."}],
   "conventions": {
-    "kmesh_ladder": {"base": 0, "rung_0": "gamma_only", "max_kpoints_per_axis": 50}
+    "kmesh_ladder": {"base": 1, "rung_1": "gamma_only", "min_k_distance": 0.03}
   },
   "provenance": {"code": "quantum_espresso", "calculation": "scf", "spin": "none"}
 }

--- a/docs/reference/kmesh.md
+++ b/docs/reference/kmesh.md
@@ -32,11 +32,9 @@ same scale.
 The rung's position, **1-based**, with rung 1 the Γ-only `(1, 1, 1)` mesh. Each
 step up is the next denser mesh the reciprocal lattice admits.
 
-Record `d5ds2-64f16` predates this convention and is 0-based; see
-[published records](../published-records.md).
-
 `kindex` only means something together with the resolution floor
 `min_k_distance` that bounded the ladder — see [the ladder](#the-ladder) below.
+Read the base and the floor from a record rather than assuming them.
 
 ## `mesh`
 
@@ -73,14 +71,10 @@ took. The two ends are different numbers for the same mesh.
     `k_dist_right` for its **upper** bound, so for `kindex 21` above it gives
     `k_dist_left = 0.11504` and `k_dist_right = 0.12389`.
 
-    The published record
-    [`d5ds2-64f16`](https://data-collections.psdi.ac.uk/records/d5ds2-64f16)
-    uses the opposite orientation — its `k_dist_interval` is written
-    `[0.123, 0.115)`, larger value first, because a larger k-distance means a
-    coarser mesh.
-
-    Joining notebook output with that record without checking will swap the
-    bounds. Compare magnitudes, not column names. Tracked as
+    Published records write `k_dist_interval` the other way round — larger value
+    first, `[0.12389, 0.11504)`, because a larger k-distance means a coarser
+    mesh. Joining notebook output with a record without checking will swap the
+    bounds: compare magnitudes, not column names. Tracked as
     [#30](https://github.com/stfc/goldilocks-data/issues/30).
 
 ## `k_line_density_interval`


### PR DESCRIPTION
Published-records now lists only the current record (52713-55d86). Drop the d5ds2-64f16 section and its 0-based/cap-50 explanation, de-reference it from the kmesh page, and update the publishing example's convention block to the floor.