### PR TITLE
docs(nav): group the standalone pages into sections

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,9 +51,10 @@ nav:
   - Data campaigns:
       - Overview: campaigns/index.md
       - QE SCF k-points: campaigns/qe-kpoints.md
-  - Results: results.md
-  - Published records: published-records.md
-  - Publish a dataset: publishing.md
+      - Results: results.md
+  - Publishing:
+      - Published records: published-records.md
+      - Publish a dataset: publishing.md
   - Reference:
       - Repository layout: reference/repository.md
       - k-mesh quantities: reference/kmesh.md


### PR DESCRIPTION
With navigation.sections, a top-level nav section renders as a bold heading and a top-level page as a link, so Results / Published records / Publish a dataset looked different from the sections beside them at the same indent. Move Results under Data campaigns and add a Publishing section for the other two.