### PR TITLE
chore: allow agents to file issues and push branches

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue create:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(gh issue edit:*)",
+      "Bash(git push:*)"
+    ]
+  }
+}


### PR DESCRIPTION
Add .claude/settings.json permitting gh issue create/comment/edit and git push without a prompt. AGENTS.md already expects agent-authored issues (with the attribution line) and agent-prepared pushed branches.