### PR TITLE
docs: add the nscf band-structure record and a package install page

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -1,6 +1,14 @@
 # Installation
 
-Reproducing the current campaign has two separate setup stages:
+How much you install depends on what you want to do.
+
+| You want to | Install |
+| --- | --- |
+| Build a k-mesh ladder, label convergence, read a published record | [the package](package.md) |
+| Publish a dataset to PSDI | the package with the `publish` extra |
+| Run or extend a data campaign | the package, then AiiDA, then Quantum ESPRESSO |
+
+Only the last one needs the full stack, and it has two further stages:
 
 1. install AiiDA and its local services on macOS;
 2. add the Quantum ESPRESSO plugin, SCARF computer, `pw.x` code, and
@@ -12,5 +20,6 @@ conflict.
 
 ## Choose the next page
 
-[Install AiiDA on macOS](aiida-macos.md){ .md-button .md-button--primary }
+[Install goldilocks-data](package.md){ .md-button .md-button--primary }
+[Install AiiDA on macOS](aiida-macos.md){ .md-button }
 [Add Quantum ESPRESSO and SCARF](qe-scarf.md){ .md-button }

--- a/docs/installation/package.md
+++ b/docs/installation/package.md
@@ -1,0 +1,118 @@
+# Install goldilocks-data
+
+The package holds the reusable mechanics: the k-mesh ladder, AiiDA submission
+and de-duplication, convergence labelling, and the PSDI publishing command. It
+does not need AiiDA to be installed unless you are actually submitting
+calculations.
+
+`uv` manages every environment here. Do not use `pip`.
+
+## From the repository
+
+This is what you want for campaign work, because the campaign scripts and the
+notebook live in the repository too.
+
+```bash
+git clone https://github.com/stfc/goldilocks-data.git
+cd goldilocks-data
+uv sync
+uv run goldilocks-data --help
+```
+
+`uv sync` creates `.venv` and installs the package in editable mode. Prefix
+commands with `uv run` and the environment is used without activating anything.
+
+## As a dependency of another project
+
+The package is not on PyPI. Add it from GitHub:
+
+```bash
+uv add "goldilocks-data @ git+https://github.com/stfc/goldilocks-data"
+```
+
+Pin a commit or a tag for anything reproducible:
+
+```bash
+uv add "goldilocks-data @ git+https://github.com/stfc/goldilocks-data@v0.1.0"
+```
+
+## What comes with the base install
+
+`pandas` and `pymatgen`.
+
+`pymatgen` is a plain dependency and not an extra on purpose. The k-mesh ladder
+reads the reciprocal lattice throughout and reduces every rung by symmetry, so
+a caller needs a real pymatgen `Structure` either way — and the reduction never
+falls back to an unreduced count, because a wrong `n_reduced_kpoints` is an
+ordinary-looking integer. See [k-mesh quantities](../reference/kmesh.md).
+
+That base is enough to build a ladder, label convergence, and read a published
+record.
+
+## Optional extras
+
+| Extra | Installs | Needed for |
+| --- | --- | --- |
+| `aiida` | `aiida-core`, `aiida-quantumespresso` | submitting sweeps, querying the database, remote-folder cleanup |
+| `kmesh` | `pyarrow` | reading the parquet campaign-record snapshots |
+| `publish` | `data-collections-api` | `goldilocks-data publish`, the PSDI deposit command |
+
+Add them to a clone with `--extra`:
+
+```bash
+uv sync --extra aiida --extra kmesh
+```
+
+Or run a single command with the extras it needs and nothing else:
+
+```bash
+uv run --extra aiida --extra kmesh python \
+  campaigns/qe/kpoints/scripts/monitor.py --once --cif-dir /path/to/CIF_files
+```
+
+!!! note "The `kmesh` extra no longer matches its name"
+
+    It once carried the k-mesh machinery. That moved into the base install when
+    `pymatgen` did, and what is left is the parquet reader the campaign scripts
+    need. The name is kept because campaign commands and shell history use it.
+
+The `aiida` extra installs the Python side only. A working AiiDA profile,
+services, and a configured computer and code are a separate setup — see
+[Install AiiDA on macOS](aiida-macos.md) and
+[Add Quantum ESPRESSO and SCARF](qe-scarf.md).
+
+## Development
+
+```bash
+uv sync --group dev
+uv run pytest
+uv run ruff check src tests campaigns/qe/kpoints/scripts
+uv run ruff format src tests campaigns/qe/kpoints/scripts
+```
+
+The docs site:
+
+```bash
+uv sync --group docs
+uv run mkdocs serve          # http://127.0.0.1:8000
+uv run mkdocs build --strict
+```
+
+`--strict` turns a broken internal link into a build failure, which is what CI
+runs.
+
+## Check it works
+
+```bash
+uv run python -c "
+from pymatgen.core import Lattice, Structure
+from goldilocks_data.kmesh import build_gamma_kmesh_entries
+
+silicon = Structure.from_spacegroup('Fd-3m', Lattice.cubic(5.43), ['Si'], [[0, 0, 0]])
+entry = build_gamma_kmesh_entries(silicon, min_k_distance=0.2)[-1]
+print(entry.kindex, entry.mesh, entry.n_reduced_kpoints)
+"
+```
+
+Diamond silicon prints `5 (5, 5, 5) 10`: rung 5 of its ladder, a 125-point mesh
+that symmetry reduces to 10. A `10` here means the reduction ran.

--- a/docs/published-records.md
+++ b/docs/published-records.md
@@ -56,6 +56,71 @@ and it is the raw per-calculation dump rather than a convergence-label table.
 This record predates the k-mesh ladder convention and carries meshes and
 k-distances directly, not a `k_index`.
 
+## Quantum ESPRESSO band structures (MC3D, nscf)
+
+<!-- Placeholder: replace with the record link and version once the PSDI draft
+     is reviewed and submitted. -->
+*Record link to be added — the deposit is with PSDI and not yet published.* ·
+CC BY 4.0
+
+Non-self-consistent band-structure calculations for **19,405 MC3D structures**:
+one summary row per material, the primitive cell the bands were computed on, and
+the eigenvalues along the high-symmetry k-point path. Every structure has all
+three — there is no row without a structure file and none without a band table.
+
+Same settings and the same family of structures as the k-index record above.
+That one answers *which mesh is dense enough*; this one answers *what the band
+structure says about the material*.
+
+| File | Contents |
+| --- | --- |
+| `nscf_band_summary.csv` | 19,405 rows: identifiers, Fermi energy, `metallicity`, `band_gap_ev` |
+| `CIF_files.tar.gz` | 19,405 primitive cells, `CIF_files/<source_db_id>.cif` |
+| `bands.tar.gz` | 19,405 eigenvalue tables, `bands/<source_db_id>.csv` |
+| `example.py` | Loads all three from the tarballs and plots one band structure |
+
+9,854 rows are `metal` and 9,551 `insulator`. `band_gap_ev` is populated for
+exactly the insulators and empty for exactly the metals.
+
+### `metallicity` is a zero threshold, not a physical one
+
+A row is `insulator` when the band structure has a gap at the Fermi level, with
+no tolerance at all: the smallest gap in the table is **0.0016 eV**, and nothing
+was rounded down. A PBEsol gap of a few meV is well inside the error of the
+method, and a practitioner would treat such a system as metallic.
+
+No thresholded label is published. A threshold frozen into an immutable record
+becomes a convention every consumer then has to discover and match — the same
+failure that forced the first dataset's `k_index` column to be recomputed
+wholesale. The gap is the fact; the cut belongs to the person using it, and
+`band_gap_ev` is published raw so it can be made.
+
+Anything downstream that trains on this column should name the threshold in
+its own target name, so that a later dataset built on a different cut cannot be
+mistaken for this one.
+
+### The k-point coordinates were reconstructed, and checked
+
+The eigenvalue tables as calculated carried no k-point coordinates. The path
+came from SeeKpath through the standard `PwBandsWorkChain`, so it was
+regenerated per structure — the campaign did not use a single sampling density,
+so the density was determined structure by structure.
+
+A reconstruction was accepted only when it matched the calculation's own record
+of the labelled points on **all four** of: number of k-points, labels, label
+positions in the table, and label coordinates. That makes the match a
+verification rather than an assumption, and it doubles as a detector.
+
+Two groups are excluded from the record entirely — structure, summary row and
+bands alike:
+
+| Excluded | Why |
+| --- | --- |
+| 104 structures | the regenerated path did not match, rather than publish coordinates that might not be theirs |
+| 80 structures | their eigenvalue tables were not in the working archive |
+
+The eigenvalues themselves are copied unchanged from the calculation output.
+
 ## Publishing another one
 
 See [Publish a dataset](publishing.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
   - Home: index.md
   - Installation:
       - Overview: installation/index.md
+      - Install goldilocks-data: installation/package.md
       - AiiDA on macOS: installation/aiida-macos.md
       - Quantum ESPRESSO and SCARF: installation/qe-scarf.md
   - Data campaigns:


### PR DESCRIPTION
published-records.md gains the MC3D nscf band-structure dataset: what the three files hold, why metallicity uses a plain zero threshold, and how the k-point coordinates were reconstructed and on what evidence they were accepted. The record link is a placeholder until the PSDI draft is submitted and published.

installation/ gains a page on installing goldilocks-data itself -- from a clone or as a git dependency, what the base install carries and why pymatgen is in it rather than in an extra, what each extra is actually for, and a snippet whose output shows the symmetry reduction ran.

The installation overview becomes a router: most readers need the package alone, not the whole AiiDA and QE stack.