### PR TITLE
gitignore: keep the run rig in campaigns/, untracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,12 @@ CLAUDE.md
 /docs/PLAN.en.md
 /site/
 
+# The rig that drives one concrete run -- controller scripts, its AiiDA group
+# and profile, its dated export tables -- is operational, not reusable, and
+# naming a live group in a public repository advertises unpublished work. It
+# stays here on disk, where uv and the scripts' own relative paths still work,
+# and out of git.
+/campaigns/
+
 # Intermediate analysis caches are reproducible and can be large.
 *.pkl


### PR DESCRIPTION
Same treatment as /notebooks/ and docs/PLAN.md: local, in place, out of git. Moving it out of the repository would have broken it -- monitor.py resolves the repository root as parents[4] of its own path and runs the controller with that as cwd, so uv would no longer find the project.